### PR TITLE
fix(cli-models): opencode 모델 목록이 표시되지 않는 버그 수정

### DIFF
--- a/server/modules/routes/ops.ts
+++ b/server/modules/routes/ops.ts
@@ -1311,7 +1311,7 @@ app.put("/api/oauth/accounts/:id", (req, res) => {
 // OAuth Provider Model Listing
 // ---------------------------------------------------------------------------
 async function fetchOpenCodeModels(): Promise<Record<string, string[]>> {
-  const grouped: Record<string, string[]> = {};
+  const grouped: Record<string, string[]> = { opencode: [] };
   try {
     const output = await execWithTimeout("opencode", ["models"], 10_000);
     for (const line of output.split(/\r?\n/)) {
@@ -1322,10 +1322,11 @@ async function fetchOpenCodeModels(): Promise<Record<string, string[]>> {
       if (provider === "github-copilot") {
         if (!grouped.copilot) grouped.copilot = [];
         grouped.copilot.push(trimmed);
-      }
-      if (provider === "google" && trimmed.includes("antigravity")) {
+      } else if (provider === "google" && trimmed.includes("antigravity")) {
         if (!grouped.antigravity) grouped.antigravity = [];
         grouped.antigravity.push(trimmed);
+      } else {
+        grouped.opencode.push(trimmed);
       }
     }
   } catch {


### PR DESCRIPTION
## 문제

OpenCode 설정 탭에서 모델 선택 드롭다운에 **"모델 목록 없음"** 이 표시되는 버그입니다.

`opencode models` CLI는 정상적으로 모델 목록을 반환하지만, 서버의 `fetchOpenCodeModels()` 함수가 `github-copilot/` 및 `google/antigravity` 접두사 모델만 추출하고 나머지(`opencode/*`, `openrouter/*`, `anthropic/*` 등)를 모두 무시했습니다.

## 원인

```ts
// 수정 전: copilot과 antigravity만 처리, 나머지는 else 없이 버려짐
if (provider === "github-copilot") { ... }
if (provider === "google" && trimmed.includes("antigravity")) { ... }
// ← else 없음 → opencode 고유 모델이 전부 누락
```

## 수정

copilot/antigravity 외 모든 모델을 `opencode` 목록에 추가하는 `else` 분기를 추가했습니다.

```ts
} else {
  grouped.opencode.push(trimmed);
}
```

## 확인

`opencode models` 실행 시 나오는 `openrouter/anthropic/claude-sonnet-4.6` 등의 모델이 OpenCode 모델 드롭다운에 정상적으로 표시됩니다.

---

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)