### PR TITLE
docs: add question issue template and enhance PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,40 @@
+name: Question
+description: Ask a question about Claw-Empire usage, setup, or internals.
+title: "[Question] "
+labels:
+  - question
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template when you have a question that isn't a bug report or feature request.
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What are you trying to do? Provide relevant background.
+      placeholder: e.g. I'm setting up OpenClaw with Telegram and...
+    validations:
+      required: true
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What do you want to know?
+      placeholder: Your question here.
+    validations:
+      required: true
+  - type: textarea
+    id: tried
+    attributes:
+      label: What I've Tried
+      description: Anything you already looked into or attempted.
+      placeholder: |
+        - Checked README section on ...
+        - Ran `pnpm dev:local` and saw ...
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: App version/tag/commit hash (if relevant).
+      placeholder: v1.2.0 / main@abcdef1

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,20 @@
+## Summary
+
+<!-- What does this PR do? Keep it brief (1-3 sentences). -->
+
+## Related Issue
+
+<!-- Link the issue this PR addresses. Use "Closes #123" to auto-close on merge. -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / code improvement
+- [ ] Documentation
+- [ ] CI / build / tooling
+- [ ] Other (describe below)
+
 ## Base Branch Policy
 
 - External contributor PRs must target `dev`.
@@ -8,10 +25,12 @@
 
 - [ ] Base branch is `dev` (or emergency hotfix to `main` with rationale below)
 - [ ] Linked issue or context is included
-- [ ] Build/tests were run locally (or reason provided if skipped)
+- [ ] `pnpm run format:check` passes
+- [ ] `pnpm run lint` passes
+- [ ] `pnpm run build` passes
+- [ ] `pnpm run test:ci` passes (or reason provided if skipped)
 - [ ] Docs/README were updated if behavior or setup changed
 
 ## Hotfix Rationale (required only when base is `main`)
 
 <!-- Explain why this must go directly to main and who approved it. -->
-


### PR DESCRIPTION
## Summary

Add a Question issue template and enhance the existing PR template to improve contributor experience.

Ref: https://github.com/GreenSheep01201/claw-empire/discussions/35

## Changes

- **`.github/ISSUE_TEMPLATE/question.yml`** (new) — Structured question template with Context, Question, What I've Tried, and Version fields. Auto-applies `question` label.
- **`.github/pull_request_template.md`** (enhanced) — Added Summary, Related Issue (`Closes #`), and Type of Change sections. Aligned checklist with CI pipeline (`format:check` → `lint` → `build` → `test:ci`). Existing Base Branch Policy and Hotfix Rationale sections preserved.

## Checklist

- [x] Base branch is `dev`
- [x] Linked issue or context is included
- [x] No code changes — templates only