### PR TITLE
[Feature] Add official OpenCode Go / Bailian Coding Plan API presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,6 +728,22 @@ Use only a plain executable + fixed args format (no shell/interpreter wrappers, 
 
 ## Provider Setup (CLI / OAuth / API)
 
+### Official API presets
+
+The **Settings > API** tab now includes four official direct-API presets:
+
+- `OpenCode Go (OpenAI)` -> `https://opencode.ai/zen/go/v1`
+- `OpenCode Go (Anthropic)` -> `https://opencode.ai/zen/go/v1`
+- `Alibaba Coding Plan (OpenAI)` -> `https://coding-intl.dashscope.aliyuncs.com/v1`
+- `Alibaba Coding Plan (Anthropic)` -> `https://coding-intl.dashscope.aliyuncs.com/apps/anthropic`
+
+Notes:
+
+- Alibaba Coding Plan API keys must start with `sk-sp-`.
+- These presets seed fallback model lists immediately so agents can be assigned even when live `/models` discovery is unavailable or incomplete.
+- Direct API presets use the provider endpoint model IDs such as `glm-5`, `kimi-k2.5`, and `minimax-m2.5`. They do **not** use OpenCode CLI model IDs like `opencode-go/<model-id>`.
+- Alibaba's Coding Plan keys are intended for the interactive coding tool flow. Review the provider documentation before reusing those keys in other environments.
+
 Claw-Empire supports three provider paths:
 
 - **CLI tools** — install local coding CLIs and run tasks through local processes

--- a/README.md
+++ b/README.md
@@ -734,15 +734,15 @@ The **Settings > API** tab now includes four official direct-API presets:
 
 - `OpenCode Go (OpenAI)` -> `https://opencode.ai/zen/go/v1`
 - `OpenCode Go (Anthropic)` -> `https://opencode.ai/zen/go/v1`
-- `Alibaba Coding Plan (OpenAI)` -> `https://coding-intl.dashscope.aliyuncs.com/v1`
-- `Alibaba Coding Plan (Anthropic)` -> `https://coding-intl.dashscope.aliyuncs.com/apps/anthropic`
+- `Bailian Coding Plan (OpenAI)` -> `https://coding-intl.dashscope.aliyuncs.com/v1`
+- `Bailian Coding Plan (Anthropic)` -> `https://coding-intl.dashscope.aliyuncs.com/apps/anthropic`
 
 Notes:
 
-- Alibaba Coding Plan API keys must start with `sk-sp-`.
+- Bailian Coding Plan API keys must start with `sk-sp-`.
 - These presets seed fallback model lists immediately so agents can be assigned even when live `/models` discovery is unavailable or incomplete.
 - Direct API presets use the provider endpoint model IDs such as `glm-5`, `kimi-k2.5`, and `minimax-m2.5`. They do **not** use OpenCode CLI model IDs like `opencode-go/<model-id>`.
-- Alibaba's Coding Plan keys are intended for the interactive coding tool flow. Review the provider documentation before reusing those keys in other environments.
+- Bailian Coding Plan keys are intended for the interactive coding tool flow. Review the provider documentation before reusing those keys in other environments.
 
 Claw-Empire supports three provider paths:
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -734,15 +734,15 @@ GitHub에 더 최신 릴리즈가 게시되면, Claw-Empire는 UI 상단에 pull
 
 - `OpenCode Go (OpenAI)` -> `https://opencode.ai/zen/go/v1`
 - `OpenCode Go (Anthropic)` -> `https://opencode.ai/zen/go/v1`
-- `Alibaba Coding Plan (OpenAI)` -> `https://coding-intl.dashscope.aliyuncs.com/v1`
-- `Alibaba Coding Plan (Anthropic)` -> `https://coding-intl.dashscope.aliyuncs.com/apps/anthropic`
+- `Bailian Coding Plan (OpenAI)` -> `https://coding-intl.dashscope.aliyuncs.com/v1`
+- `Bailian Coding Plan (Anthropic)` -> `https://coding-intl.dashscope.aliyuncs.com/apps/anthropic`
 
 메모:
 
-- Alibaba Coding Plan API 키는 반드시 `sk-sp-` 접두사로 시작해야 합니다.
+- Bailian Coding Plan API 키는 반드시 `sk-sp-` 접두사로 시작해야 합니다.
 - 이 프리셋들은 저장 즉시 fallback 모델 목록을 시드하므로, live `/models` 조회가 불완전하거나 실패해도 바로 에이전트에 배정할 수 있습니다.
 - direct API 프리셋은 `glm-5`, `kimi-k2.5`, `minimax-m2.5` 같은 실제 endpoint model id를 사용합니다. `opencode-go/<model-id>` 같은 OpenCode CLI 모델 ID를 쓰지 않습니다.
-- Alibaba Coding Plan 키는 인터랙티브 코딩 도구 흐름용으로 안내되는 키입니다. 다른 환경에 재사용하기 전에 공식 문서를 확인하세요.
+- Bailian Coding Plan 키는 인터랙티브 코딩 도구 흐름용으로 안내되는 키입니다. 다른 환경에 재사용하기 전에 공식 문서를 확인하세요.
 
 Claw-Empire는 아래 3가지 방식의 프로바이더를 지원합니다:
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -728,6 +728,22 @@ GitHub에 더 최신 릴리즈가 게시되면, Claw-Empire는 UI 상단에 pull
 
 ## 프로바이더 설정 (CLI / OAuth / API)
 
+### 공식 API 프리셋
+
+이제 **Settings > API** 탭에서 다음 4개의 공식 direct API 프리셋을 바로 추가할 수 있습니다.
+
+- `OpenCode Go (OpenAI)` -> `https://opencode.ai/zen/go/v1`
+- `OpenCode Go (Anthropic)` -> `https://opencode.ai/zen/go/v1`
+- `Alibaba Coding Plan (OpenAI)` -> `https://coding-intl.dashscope.aliyuncs.com/v1`
+- `Alibaba Coding Plan (Anthropic)` -> `https://coding-intl.dashscope.aliyuncs.com/apps/anthropic`
+
+메모:
+
+- Alibaba Coding Plan API 키는 반드시 `sk-sp-` 접두사로 시작해야 합니다.
+- 이 프리셋들은 저장 즉시 fallback 모델 목록을 시드하므로, live `/models` 조회가 불완전하거나 실패해도 바로 에이전트에 배정할 수 있습니다.
+- direct API 프리셋은 `glm-5`, `kimi-k2.5`, `minimax-m2.5` 같은 실제 endpoint model id를 사용합니다. `opencode-go/<model-id>` 같은 OpenCode CLI 모델 ID를 쓰지 않습니다.
+- Alibaba Coding Plan 키는 인터랙티브 코딩 도구 흐름용으로 안내되는 키입니다. 다른 환경에 재사용하기 전에 공식 문서를 확인하세요.
+
 Claw-Empire는 아래 3가지 방식의 프로바이더를 지원합니다:
 
 - **CLI 도구** — 로컬 CLI 설치 후 프로세스 기반으로 실행

--- a/server/modules/bootstrap/schema/api-providers-schema.test.ts
+++ b/server/modules/bootstrap/schema/api-providers-schema.test.ts
@@ -1,0 +1,125 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { applyBaseSchema } from "./base-schema.ts";
+import { initializeOAuthRuntime } from "./oauth-runtime.ts";
+import { applyTaskSchemaMigrations } from "./task-schema-migrations.ts";
+
+function tableColumns(db: DatabaseSync, table: string): string[] {
+  return (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).map((column) => column.name);
+}
+
+function runInTransaction(db: DatabaseSync, fn: () => void): void {
+  db.exec("BEGIN");
+  try {
+    fn();
+    db.exec("COMMIT");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    throw error;
+  }
+}
+
+describe("api_providers schema migrations", () => {
+  it("adds preset_key to legacy rows via task migrations", () => {
+    const db = new DatabaseSync(":memory:");
+
+    try {
+      applyBaseSchema(db);
+      db.exec("DROP TABLE api_providers");
+      db.exec(`
+        CREATE TABLE api_providers (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          type TEXT NOT NULL DEFAULT 'openai' CHECK(type IN ('openai','anthropic','google','ollama','openrouter','together','groq','cerebras','custom')),
+          base_url TEXT NOT NULL,
+          api_key_enc TEXT,
+          enabled INTEGER NOT NULL DEFAULT 1,
+          models_cache TEXT,
+          models_cached_at INTEGER,
+          created_at INTEGER DEFAULT (unixepoch()*1000),
+          updated_at INTEGER DEFAULT (unixepoch()*1000)
+        );
+      `);
+      db.prepare(
+        `
+          INSERT INTO api_providers (id, name, type, base_url, enabled, created_at, updated_at)
+          VALUES (?, ?, ?, ?, 1, ?, ?)
+        `,
+      ).run("legacy-provider", "Legacy Provider", "openai", "https://api.openai.com/v1", 100, 100);
+
+      applyTaskSchemaMigrations(db);
+
+      expect(tableColumns(db, "api_providers")).toContain("preset_key");
+      const row = db.prepare("SELECT id, name, preset_key FROM api_providers WHERE id = ?").get("legacy-provider") as {
+        id: string;
+        name: string;
+        preset_key: string | null;
+      };
+      expect(row).toEqual({
+        id: "legacy-provider",
+        name: "Legacy Provider",
+        preset_key: null,
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("oauth runtime legacy rebuild keeps rows and adds preset_key", () => {
+    const db = new DatabaseSync(":memory:");
+
+    try {
+      applyBaseSchema(db);
+      db.exec("DROP TABLE api_providers");
+      db.exec(`
+        CREATE TABLE api_providers (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          type TEXT NOT NULL DEFAULT 'openai' CHECK(type IN ('openai','anthropic','google','ollama','openrouter','together','groq','custom')),
+          base_url TEXT NOT NULL,
+          api_key_enc TEXT,
+          enabled INTEGER NOT NULL DEFAULT 1,
+          models_cache TEXT,
+          models_cached_at INTEGER,
+          created_at INTEGER DEFAULT (unixepoch()*1000),
+          updated_at INTEGER DEFAULT (unixepoch()*1000)
+        );
+      `);
+      db.prepare(
+        `
+          INSERT INTO api_providers (id, name, type, base_url, enabled, created_at, updated_at)
+          VALUES (?, ?, ?, ?, 1, ?, ?)
+        `,
+      ).run("old-provider", "Old Provider", "openai", "https://api.openai.com/v1", 200, 200);
+
+      initializeOAuthRuntime({
+        db,
+        nowMs: () => 1_717_171_717_000,
+        runInTransaction: (fn) => runInTransaction(db, fn),
+      });
+
+      expect(tableColumns(db, "api_providers")).toContain("preset_key");
+      const row = db
+        .prepare("SELECT type, base_url, preset_key FROM api_providers WHERE id = ?")
+        .get("old-provider") as {
+        type: string;
+        base_url: string;
+        preset_key: string | null;
+      };
+      expect(row).toEqual({
+        type: "openai",
+        base_url: "https://api.openai.com/v1",
+        preset_key: null,
+      });
+
+      const tableSql = (
+        db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'api_providers'").get() as
+          | { sql?: string }
+          | undefined
+      )?.sql;
+      expect(tableSql).toContain("'cerebras'");
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/server/modules/bootstrap/schema/base-schema.ts
+++ b/server/modules/bootstrap/schema/base-schema.ts
@@ -368,6 +368,7 @@ CREATE TABLE IF NOT EXISTS api_providers (
   type TEXT NOT NULL DEFAULT 'openai' CHECK(type IN ('openai','anthropic','google','ollama','openrouter','together','groq','cerebras','custom')),
   base_url TEXT NOT NULL,
   api_key_enc TEXT,
+  preset_key TEXT,
   enabled INTEGER NOT NULL DEFAULT 1,
   models_cache TEXT,
   models_cached_at INTEGER,

--- a/server/modules/bootstrap/schema/oauth-runtime.ts
+++ b/server/modules/bootstrap/schema/oauth-runtime.ts
@@ -168,7 +168,9 @@ export function initializeOAuthRuntime(deps: OAuthRuntimeDeps): OAuthRuntimeHelp
   try {
     const apiProvSql =
       (db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='api_providers'").get() as any)?.sql ?? "";
-    if (apiProvSql && !apiProvSql.includes("'cerebras'")) {
+    const apiProvCols = db.prepare("PRAGMA table_info(api_providers)").all() as Array<{ name: string }>;
+    const hasPresetKey = apiProvCols.some((c) => c.name === "preset_key");
+    if (apiProvSql && (!apiProvSql.includes("'cerebras'") || !hasPresetKey)) {
       db.exec(`
       CREATE TABLE IF NOT EXISTS api_providers_new (
         id TEXT PRIMARY KEY,
@@ -176,13 +178,21 @@ export function initializeOAuthRuntime(deps: OAuthRuntimeDeps): OAuthRuntimeHelp
         type TEXT NOT NULL DEFAULT 'openai' CHECK(type IN ('openai','anthropic','google','ollama','openrouter','together','groq','cerebras','custom')),
         base_url TEXT NOT NULL,
         api_key_enc TEXT,
+        preset_key TEXT,
         enabled INTEGER NOT NULL DEFAULT 1,
         models_cache TEXT,
         models_cached_at INTEGER,
         created_at INTEGER DEFAULT (unixepoch()*1000),
         updated_at INTEGER DEFAULT (unixepoch()*1000)
       );
-      INSERT INTO api_providers_new SELECT * FROM api_providers;
+      INSERT INTO api_providers_new (
+        id, name, type, base_url, api_key_enc, preset_key, enabled,
+        models_cache, models_cached_at, created_at, updated_at
+      )
+      SELECT
+        id, name, type, base_url, api_key_enc, ${hasPresetKey ? "preset_key" : "NULL"},
+        enabled, models_cache, models_cached_at, created_at, updated_at
+      FROM api_providers;
       DROP TABLE api_providers;
       ALTER TABLE api_providers_new RENAME TO api_providers;
     `);

--- a/server/modules/bootstrap/schema/task-schema-migrations.ts
+++ b/server/modules/bootstrap/schema/task-schema-migrations.ts
@@ -41,6 +41,11 @@ export function applyTaskSchemaMigrations(db: DbLike): void {
   } catch {
     /* project_id not ready yet */
   }
+  try {
+    db.exec("ALTER TABLE api_providers ADD COLUMN preset_key TEXT");
+  } catch {
+    /* already exists */
+  }
   // Task creation audit completion flag
   try {
     db.exec("ALTER TABLE task_creation_audits ADD COLUMN completed INTEGER NOT NULL DEFAULT 0");

--- a/server/modules/routes/ops/api-providers.test.ts
+++ b/server/modules/routes/ops/api-providers.test.ts
@@ -1,0 +1,222 @@
+import express from "express";
+import request from "supertest";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { applyBaseSchema } from "../../bootstrap/schema/base-schema.ts";
+import { applyTaskSchemaMigrations } from "../../bootstrap/schema/task-schema-migrations.ts";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function createHarness(now = 1_717_171_717_000) {
+  process.env.SESSION_SECRET = "api-provider-test-secret";
+  vi.resetModules();
+
+  const db = new DatabaseSync(":memory:");
+  applyBaseSchema(db);
+  applyTaskSchemaMigrations(db);
+
+  const app = express();
+  app.use(express.json());
+
+  const { registerApiProviderRoutes } = await import("./api-providers.ts");
+  registerApiProviderRoutes({
+    app,
+    db,
+    nowMs: () => now,
+  });
+
+  return { app, db };
+}
+
+describe("api provider routes", () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV, SESSION_SECRET: "api-provider-test-secret" };
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns generic presets and official preset catalog", async () => {
+    const { app, db } = await createHarness();
+
+    try {
+      const response = await request(app).get("/api/api-providers/presets").expect(200);
+
+      expect(response.body.ok).toBe(true);
+      expect(response.body.presets.openai.base_url).toBe("https://api.openai.com/v1");
+      expect(response.body.official_presets["opencode-go-openai"]).toMatchObject({
+        type: "openai",
+        base_url: "https://opencode.ai/zen/go/v1",
+      });
+      expect(response.body.official_presets["alibaba-coding-plan-openai"].fallback_models).toContain("qwen3.5-plus");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("creates a preset-backed provider with authoritative type/base_url and seeded models", async () => {
+    const { app, db } = await createHarness();
+
+    try {
+      const createResponse = await request(app).post("/api/api-providers").send({
+        name: "OpenCode Go",
+        type: "custom",
+        base_url: "https://example.com/not-used",
+        preset_key: "opencode-go-openai",
+        api_key: "sk-test-open",
+      });
+
+      expect(createResponse.status).toBe(200);
+      expect(createResponse.body.ok).toBe(true);
+
+      const row = db
+        .prepare(
+          `
+            SELECT name, type, base_url, preset_key, models_cache, models_cached_at
+            FROM api_providers
+            WHERE id = ?
+          `,
+        )
+        .get(createResponse.body.id) as
+        | {
+            name: string;
+            type: string;
+            base_url: string;
+            preset_key: string | null;
+            models_cache: string | null;
+            models_cached_at: number | null;
+          }
+        | undefined;
+
+      expect(row).toMatchObject({
+        name: "OpenCode Go",
+        type: "openai",
+        base_url: "https://opencode.ai/zen/go/v1",
+        preset_key: "opencode-go-openai",
+      });
+      expect(JSON.parse(String(row?.models_cache))).toEqual(["glm-5", "kimi-k2.5"]);
+      expect(row?.models_cached_at).toBe(1_717_171_717_000);
+
+      const listResponse = await request(app).get("/api/api-providers").expect(200);
+      expect(listResponse.body.providers[0]).toMatchObject({
+        preset_key: "opencode-go-openai",
+        type: "openai",
+        base_url: "https://opencode.ai/zen/go/v1",
+        models_cache: ["glm-5", "kimi-k2.5"],
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("rejects invalid Alibaba Coding Plan API keys on update", async () => {
+    const { app, db } = await createHarness();
+
+    try {
+      const insertResult = db
+        .prepare(
+          `
+            INSERT INTO api_providers (id, name, type, base_url, enabled, created_at, updated_at)
+            VALUES (?, ?, ?, ?, 1, ?, ?)
+          `,
+        )
+        .run("provider-1", "Legacy", "openai", "https://api.openai.com/v1", 1_000, 1_000);
+
+      expect(insertResult.changes).toBe(1);
+
+      const response = await request(app).put("/api/api-providers/provider-1").send({
+        preset_key: "alibaba-coding-plan-openai",
+        api_key: "sk-invalid-prefix",
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain("sk-sp-");
+
+      const row = db.prepare("SELECT preset_key, models_cache FROM api_providers WHERE id = ?").get("provider-1") as {
+        preset_key: string | null;
+        models_cache: string | null;
+      };
+      expect(row.preset_key).toBeNull();
+      expect(row.models_cache).toBeNull();
+    } finally {
+      db.close();
+    }
+  });
+
+  it("merges fetched models with preset fallback models during test", async () => {
+    const { app, db } = await createHarness();
+
+    try {
+      const createResponse = await request(app).post("/api/api-providers").send({
+        name: "OpenCode Go",
+        type: "openai",
+        base_url: "https://ignored.example",
+        preset_key: "opencode-go-openai",
+      });
+
+      const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse({ data: [{ id: "glm-5" }, { id: "deepseek-v3" }] }));
+      vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+      const response = await request(app).post(`/api/api-providers/${createResponse.body.id}/test`).expect(200);
+
+      expect(response.body).toMatchObject({
+        ok: true,
+        model_count: 3,
+        models: ["glm-5", "kimi-k2.5", "deepseek-v3"],
+      });
+
+      const row = db.prepare("SELECT models_cache FROM api_providers WHERE id = ?").get(createResponse.body.id) as {
+        models_cache: string | null;
+      };
+      expect(JSON.parse(String(row.models_cache))).toEqual(["glm-5", "kimi-k2.5", "deepseek-v3"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("keeps seeded fallback cache when model refresh fails", async () => {
+    const { app, db } = await createHarness();
+
+    try {
+      const createResponse = await request(app).post("/api/api-providers").send({
+        name: "Alibaba Coding Plan",
+        type: "openai",
+        base_url: "https://ignored.example",
+        preset_key: "alibaba-coding-plan-openai",
+      });
+
+      const fetchMock = vi.fn().mockResolvedValueOnce(new Response("upstream failed", { status: 502 }));
+      vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+      const response = await request(app)
+        .get(`/api/api-providers/${createResponse.body.id}/models?refresh=true`)
+        .expect(200);
+
+      expect(response.body.ok).toBe(true);
+      expect(response.body.cached).toBe(true);
+      expect(response.body.stale).toBe(true);
+      expect(response.body.models).toEqual([
+        "qwen3.5-plus",
+        "kimi-k2.5",
+        "glm-5",
+        "MiniMax-M2.5",
+        "qwen3-max-2026-01-23",
+        "qwen3-coder-next",
+        "qwen3-coder-plus",
+        "glm-4.7",
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/server/modules/routes/ops/api-providers.test.ts
+++ b/server/modules/routes/ops/api-providers.test.ts
@@ -119,7 +119,7 @@ describe("api provider routes", () => {
     }
   });
 
-  it("rejects invalid Alibaba Coding Plan API keys on update", async () => {
+  it("rejects invalid Bailian Coding Plan API keys on update", async () => {
     const { app, db } = await createHarness();
 
     try {
@@ -189,7 +189,7 @@ describe("api provider routes", () => {
 
     try {
       const createResponse = await request(app).post("/api/api-providers").send({
-        name: "Alibaba Coding Plan",
+        name: "Bailian Coding Plan",
         type: "openai",
         base_url: "https://ignored.example",
         preset_key: "alibaba-coding-plan-openai",

--- a/server/modules/routes/ops/api-providers.test.ts
+++ b/server/modules/routes/ops/api-providers.test.ts
@@ -200,6 +200,116 @@ describe("api provider routes", () => {
       db.close();
     }
   });
+
+  it("replaces stale cached models when switching into a preset", async () => {
+    const { app, db } = await createHarness();
+
+    try {
+      const insertResult = db
+        .prepare(
+          `
+            INSERT INTO api_providers (
+              id, name, type, base_url, enabled, models_cache, models_cached_at, created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, 1, ?, ?, ?, ?)
+          `,
+        )
+        .run(
+          "provider-stale-cache",
+          "Legacy",
+          "openai",
+          "https://api.openai.com/v1",
+          JSON.stringify(["gpt-4.1", "claude-3-7-sonnet"]),
+          999,
+          1_000,
+          1_000,
+        );
+
+      expect(insertResult.changes).toBe(1);
+
+      const response = await request(app).put("/api/api-providers/provider-stale-cache").send({
+        preset_key: "opencode-go-openai",
+      });
+
+      expect(response.status).toBe(200);
+
+      const row = db
+        .prepare("SELECT preset_key, type, base_url, models_cache, models_cached_at FROM api_providers WHERE id = ?")
+        .get("provider-stale-cache") as {
+        preset_key: string | null;
+        type: string;
+        base_url: string;
+        models_cache: string | null;
+        models_cached_at: number | null;
+      };
+
+      expect(row.preset_key).toBe("opencode-go-openai");
+      expect(row.type).toBe("openai");
+      expect(row.base_url).toBe("https://opencode.ai/zen/go/v1");
+      expect(JSON.parse(String(row.models_cache))).toEqual(["glm-5", "kimi-k2.5"]);
+      expect(row.models_cached_at).toBe(1_717_171_717_000);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("clears cached models when leaving preset mode", async () => {
+    const { app, db } = await createHarness();
+
+    try {
+      const insertResult = db
+        .prepare(
+          `
+            INSERT INTO api_providers (
+              id, name, type, base_url, preset_key, enabled, models_cache, models_cached_at, created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?)
+          `,
+        )
+        .run(
+          "provider-leave-preset",
+          "Preset Provider",
+          "openai",
+          "https://opencode.ai/zen/go/v1",
+          "opencode-go-openai",
+          JSON.stringify(["glm-5", "kimi-k2.5"]),
+          1_111,
+          1_000,
+          1_000,
+        );
+
+      expect(insertResult.changes).toBe(1);
+
+      const response = await request(app).put("/api/api-providers/provider-leave-preset").send({
+        preset_key: null,
+        type: "custom",
+        base_url: "https://custom.example/v1",
+      });
+
+      expect(response.status).toBe(200);
+
+      const row = db
+        .prepare("SELECT preset_key, type, base_url, models_cache, models_cached_at FROM api_providers WHERE id = ?")
+        .get("provider-leave-preset") as {
+        preset_key: string | null;
+        type: string;
+        base_url: string;
+        models_cache: string | null;
+        models_cached_at: number | null;
+      };
+
+      expect(row).toEqual({
+        preset_key: null,
+        type: "custom",
+        base_url: "https://custom.example/v1",
+        models_cache: null,
+        models_cached_at: null,
+      });
+    } finally {
+      db.close();
+    }
+  });
+
   it("merges fetched models with preset fallback models during test", async () => {
     const { app, db } = await createHarness();
 

--- a/server/modules/routes/ops/api-providers.test.ts
+++ b/server/modules/routes/ops/api-providers.test.ts
@@ -153,6 +153,53 @@ describe("api provider routes", () => {
     }
   });
 
+  it("rejects retained invalid keys when switching to a Bailian preset", async () => {
+    const { app, db } = await createHarness();
+
+    try {
+      const { encryptSecret } = await import("../../../oauth/helpers.ts");
+      const insertResult = db
+        .prepare(
+          `
+            INSERT INTO api_providers (id, name, type, base_url, api_key_enc, enabled, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, 1, ?, ?)
+          `,
+        )
+        .run(
+          "provider-legacy-key",
+          "Legacy",
+          "openai",
+          "https://api.openai.com/v1",
+          encryptSecret("sk-legacy-openai"),
+          1_000,
+          1_000,
+        );
+
+      expect(insertResult.changes).toBe(1);
+
+      const response = await request(app).put("/api/api-providers/provider-legacy-key").send({
+        preset_key: "alibaba-coding-plan-openai",
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain("sk-sp-");
+
+      const row = db
+        .prepare("SELECT preset_key, type, base_url FROM api_providers WHERE id = ?")
+        .get("provider-legacy-key") as {
+        preset_key: string | null;
+        type: string;
+        base_url: string;
+      };
+      expect(row).toMatchObject({
+        preset_key: null,
+        type: "openai",
+        base_url: "https://api.openai.com/v1",
+      });
+    } finally {
+      db.close();
+    }
+  });
   it("merges fetched models with preset fallback models during test", async () => {
     const { app, db } = await createHarness();
 

--- a/server/modules/routes/ops/api-providers.ts
+++ b/server/modules/routes/ops/api-providers.ts
@@ -101,12 +101,12 @@ const OFFICIAL_API_PROVIDER_PRESETS = {
     fallback_models: ["minimax-m2.5"],
   },
   "alibaba-coding-plan-openai": {
-    label: "Alibaba Coding Plan (OpenAI)",
-    description: "Alibaba Cloud Coding Plan direct API preset using the OpenAI-compatible protocol.",
+    label: "Bailian Coding Plan (OpenAI)",
+    description: "Alibaba Bailian Coding Plan direct API preset using the OpenAI-compatible protocol.",
     type: "openai",
     base_url: "https://coding-intl.dashscope.aliyuncs.com/v1",
     docs_url: "https://www.alibabacloud.com/help/en/model-studio/other-tools-coding-plan",
-    api_key_hint: "Coding Plan keys for this preset must start with sk-sp-.",
+    api_key_hint: "Bailian Coding Plan keys for this preset must start with sk-sp-.",
     api_key_placeholder: "sk-sp-...",
     fallback_models: [
       "qwen3.5-plus",
@@ -121,12 +121,12 @@ const OFFICIAL_API_PROVIDER_PRESETS = {
     required_api_key_prefix: "sk-sp-",
   },
   "alibaba-coding-plan-anthropic": {
-    label: "Alibaba Coding Plan (Anthropic)",
-    description: "Alibaba Cloud Coding Plan direct API preset using the Anthropic-compatible protocol.",
+    label: "Bailian Coding Plan (Anthropic)",
+    description: "Alibaba Bailian Coding Plan direct API preset using the Anthropic-compatible protocol.",
     type: "anthropic",
     base_url: "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic",
     docs_url: "https://www.alibabacloud.com/help/en/model-studio/other-tools-coding-plan",
-    api_key_hint: "Coding Plan keys for this preset must start with sk-sp-.",
+    api_key_hint: "Bailian Coding Plan keys for this preset must start with sk-sp-.",
     api_key_placeholder: "sk-sp-...",
     fallback_models: [
       "qwen3.5-plus",

--- a/server/modules/routes/ops/api-providers.ts
+++ b/server/modules/routes/ops/api-providers.ts
@@ -20,12 +20,27 @@ type ApiProviderType =
   | "cerebras"
   | "custom";
 
+type OfficialApiProviderType = Extract<ApiProviderType, "openai" | "anthropic">;
+
+type OfficialApiProviderPreset = {
+  label: string;
+  description: string;
+  type: OfficialApiProviderType;
+  base_url: string;
+  docs_url: string;
+  api_key_hint: string;
+  api_key_placeholder: string;
+  fallback_models: string[];
+  required_api_key_prefix?: string;
+};
+
 type ApiProviderRow = {
   id: string;
   name: string;
   type: ApiProviderType;
   base_url: string;
   api_key_enc: string | null;
+  preset_key: string | null;
   enabled: number;
   models_cache: string | null;
   models_cached_at: number | null;
@@ -39,6 +54,7 @@ type ApiProviderPayload = {
   base_url?: unknown;
   api_key?: unknown;
   enabled?: unknown;
+  preset_key?: unknown;
 };
 
 interface RegisterApiProviderRoutesOptions {
@@ -63,8 +79,77 @@ const API_PROVIDER_PRESETS: Record<ApiProviderType, ApiProviderPreset> = {
   custom: { base_url: "", models_path: "/models", auth_header: "Bearer" },
 };
 
+const OFFICIAL_API_PROVIDER_PRESETS = {
+  "opencode-go-openai": {
+    label: "OpenCode Go (OpenAI)",
+    description: "OpenCode Go direct API preset using the OpenAI-compatible protocol.",
+    type: "openai",
+    base_url: "https://opencode.ai/zen/go/v1",
+    docs_url: "https://opencode.ai/docs/ko/go/",
+    api_key_hint: "Use an OpenCode Go direct API key for this endpoint.",
+    api_key_placeholder: "sk-...",
+    fallback_models: ["glm-5", "kimi-k2.5"],
+  },
+  "opencode-go-anthropic": {
+    label: "OpenCode Go (Anthropic)",
+    description: "OpenCode Go direct API preset using the Anthropic-compatible protocol.",
+    type: "anthropic",
+    base_url: "https://opencode.ai/zen/go/v1",
+    docs_url: "https://opencode.ai/docs/ko/go/",
+    api_key_hint: "Use an OpenCode Go direct API key for this endpoint.",
+    api_key_placeholder: "sk-...",
+    fallback_models: ["minimax-m2.5"],
+  },
+  "alibaba-coding-plan-openai": {
+    label: "Alibaba Coding Plan (OpenAI)",
+    description: "Alibaba Cloud Coding Plan direct API preset using the OpenAI-compatible protocol.",
+    type: "openai",
+    base_url: "https://coding-intl.dashscope.aliyuncs.com/v1",
+    docs_url: "https://www.alibabacloud.com/help/en/model-studio/other-tools-coding-plan",
+    api_key_hint: "Coding Plan keys for this preset must start with sk-sp-.",
+    api_key_placeholder: "sk-sp-...",
+    fallback_models: [
+      "qwen3.5-plus",
+      "kimi-k2.5",
+      "glm-5",
+      "MiniMax-M2.5",
+      "qwen3-max-2026-01-23",
+      "qwen3-coder-next",
+      "qwen3-coder-plus",
+      "glm-4.7",
+    ],
+    required_api_key_prefix: "sk-sp-",
+  },
+  "alibaba-coding-plan-anthropic": {
+    label: "Alibaba Coding Plan (Anthropic)",
+    description: "Alibaba Cloud Coding Plan direct API preset using the Anthropic-compatible protocol.",
+    type: "anthropic",
+    base_url: "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic",
+    docs_url: "https://www.alibabacloud.com/help/en/model-studio/other-tools-coding-plan",
+    api_key_hint: "Coding Plan keys for this preset must start with sk-sp-.",
+    api_key_placeholder: "sk-sp-...",
+    fallback_models: [
+      "qwen3.5-plus",
+      "kimi-k2.5",
+      "glm-5",
+      "MiniMax-M2.5",
+      "qwen3-max-2026-01-23",
+      "qwen3-coder-next",
+      "qwen3-coder-plus",
+      "glm-4.7",
+    ],
+    required_api_key_prefix: "sk-sp-",
+  },
+} as const satisfies Record<string, OfficialApiProviderPreset>;
+
+type OfficialApiProviderPresetKey = keyof typeof OFFICIAL_API_PROVIDER_PRESETS;
+
 function isApiProviderType(value: unknown): value is ApiProviderType {
   return typeof value === "string" && value in API_PROVIDER_PRESETS;
+}
+
+function isOfficialApiProviderPresetKey(value: unknown): value is OfficialApiProviderPresetKey {
+  return typeof value === "string" && value in OFFICIAL_API_PROVIDER_PRESETS;
 }
 
 function parseBody(req: Request): ApiProviderPayload {
@@ -74,6 +159,22 @@ function parseBody(req: Request): ApiProviderPayload {
 function readProvider(db: DatabaseSync, id: string): ApiProviderRow | null {
   const row = db.prepare("SELECT * FROM api_providers WHERE id = ?").get(id) as ApiProviderRow | undefined;
   return row ?? null;
+}
+
+function readOfficialPreset(
+  presetKey: string | null | undefined,
+): { key: OfficialApiProviderPresetKey; preset: OfficialApiProviderPreset } | null {
+  if (!presetKey || !isOfficialApiProviderPresetKey(presetKey)) return null;
+  return { key: presetKey, preset: OFFICIAL_API_PROVIDER_PRESETS[presetKey] };
+}
+
+function parsePresetKeyInput(value: unknown): { valid: boolean; presetKey: OfficialApiProviderPresetKey | null } {
+  if (value == null) return { valid: true, presetKey: null };
+  if (typeof value !== "string") return { valid: false, presetKey: null };
+  const trimmed = value.trim();
+  if (!trimmed) return { valid: true, presetKey: null };
+  if (!isOfficialApiProviderPresetKey(trimmed)) return { valid: false, presetKey: null };
+  return { valid: true, presetKey: trimmed };
 }
 
 function buildApiProviderHeaders(type: ApiProviderType, apiKey: string): Record<string, string> {
@@ -144,10 +245,32 @@ function parseModelsCache(value: string | null): string[] {
   if (!value) return [];
   try {
     const parsed = JSON.parse(value);
-    return Array.isArray(parsed) ? parsed.map((v) => String(v)) : [];
+    return Array.isArray(parsed) ? parsed.map((v) => String(v).trim()).filter((v) => v.length > 0) : [];
   } catch {
     return [];
   }
+}
+
+function mergeModelLists(...groups: ReadonlyArray<ReadonlyArray<string>>): string[] {
+  const seen = new Set<string>();
+  const merged: string[] = [];
+  for (const group of groups) {
+    for (const raw of group) {
+      const model = String(raw ?? "").trim();
+      if (!model || seen.has(model)) continue;
+      seen.add(model);
+      merged.push(model);
+    }
+  }
+  return merged;
+}
+
+function validateOfficialPresetApiKey(preset: OfficialApiProviderPreset | null, apiKey: string): string | null {
+  if (!preset?.required_api_key_prefix || !apiKey) return null;
+  if (!apiKey.startsWith(preset.required_api_key_prefix)) {
+    return `API key for ${preset.label} must start with ${preset.required_api_key_prefix}`;
+  }
+  return null;
 }
 
 function sendNotFound(res: Response): void {
@@ -162,6 +285,7 @@ export function registerApiProviderRoutes({ app, db, nowMs }: RegisterApiProvide
       name: row.name,
       type: row.type,
       base_url: row.base_url,
+      preset_key: row.preset_key ?? null,
       has_api_key: Boolean(row.api_key_enc),
       enabled: Boolean(row.enabled),
       models_cache: parseModelsCache(row.models_cache),
@@ -174,49 +298,115 @@ export function registerApiProviderRoutes({ app, db, nowMs }: RegisterApiProvide
 
   app.post("/api/api-providers", (req, res) => {
     const body = parseBody(req);
+    const presetKeyInput = parsePresetKeyInput(body.preset_key);
+    if (!presetKeyInput.valid) {
+      return res.status(400).json({ error: "invalid preset_key" });
+    }
+    const officialPreset = presetKeyInput.presetKey ? OFFICIAL_API_PROVIDER_PRESETS[presetKeyInput.presetKey] : null;
     const name = typeof body.name === "string" ? body.name.trim() : "";
-    const baseUrl = typeof body.base_url === "string" ? body.base_url.trim() : "";
-    const type: ApiProviderType = isApiProviderType(body.type) ? body.type : "openai";
-    const apiKey = typeof body.api_key === "string" ? body.api_key : "";
+    const baseUrl = officialPreset?.base_url ?? (typeof body.base_url === "string" ? body.base_url.trim() : "");
+    const type: ApiProviderType = officialPreset?.type ?? (isApiProviderType(body.type) ? body.type : "openai");
+    const apiKey = typeof body.api_key === "string" ? body.api_key.trim() : "";
 
     if (!name || !baseUrl) {
       return res.status(400).json({ error: "name and base_url are required" });
     }
 
+    const apiKeyError = validateOfficialPresetApiKey(officialPreset, apiKey);
+    if (apiKeyError) {
+      return res.status(400).json({ error: apiKeyError });
+    }
+
     const id = randomUUID();
     const now = nowMs();
+    const seededModels = mergeModelLists(officialPreset?.fallback_models ?? []);
     db.prepare(
-      "INSERT INTO api_providers (id, name, type, base_url, api_key_enc, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
-    ).run(id, name, type, baseUrl.replace(/\/+$/, ""), apiKey ? encryptSecret(apiKey) : null, now, now);
+      `
+        INSERT INTO api_providers (
+          id, name, type, base_url, api_key_enc, preset_key, enabled,
+          models_cache, models_cached_at, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?)
+      `,
+    ).run(
+      id,
+      name,
+      type,
+      baseUrl.replace(/\/+$/, ""),
+      apiKey ? encryptSecret(apiKey) : null,
+      presetKeyInput.presetKey,
+      seededModels.length ? JSON.stringify(seededModels) : null,
+      seededModels.length ? now : null,
+      now,
+      now,
+    );
     res.json({ ok: true, id });
   });
 
   app.put("/api/api-providers/:id", (req, res) => {
     const id = String(req.params.id ?? "");
+    const row = readProvider(db, id);
+    if (!row) return sendNotFound(res);
+
     const body = parseBody(req);
+    const existingPreset = readOfficialPreset(row.preset_key);
+    const presetKeyInput = "preset_key" in body ? parsePresetKeyInput(body.preset_key) : null;
+    if (presetKeyInput && !presetKeyInput.valid) {
+      return res.status(400).json({ error: "invalid preset_key" });
+    }
+    const nextPresetKey = presetKeyInput ? presetKeyInput.presetKey : (existingPreset?.key ?? null);
+    const officialPreset = nextPresetKey ? OFFICIAL_API_PROVIDER_PRESETS[nextPresetKey] : null;
     const updates: string[] = ["updated_at = ?"];
-    const params: unknown[] = [nowMs()];
+    const now = nowMs();
+    const params: unknown[] = [now];
 
     if ("name" in body && typeof body.name === "string" && body.name.trim()) {
       updates.push("name = ?");
       params.push(body.name.trim());
     }
-    if ("type" in body && isApiProviderType(body.type)) {
-      updates.push("type = ?");
-      params.push(body.type);
-    }
-    if ("base_url" in body && typeof body.base_url === "string" && body.base_url.trim()) {
-      updates.push("base_url = ?");
-      params.push(body.base_url.trim().replace(/\/+$/, ""));
-    }
     if ("api_key" in body) {
-      const apiKey = typeof body.api_key === "string" ? body.api_key : "";
+      const apiKey = typeof body.api_key === "string" ? body.api_key.trim() : "";
+      const apiKeyError = validateOfficialPresetApiKey(officialPreset, apiKey);
+      if (apiKeyError) {
+        return res.status(400).json({ error: apiKeyError });
+      }
       updates.push("api_key_enc = ?");
       params.push(apiKey ? encryptSecret(apiKey) : null);
     }
     if ("enabled" in body) {
       updates.push("enabled = ?");
       params.push(body.enabled ? 1 : 0);
+    }
+    if (officialPreset) {
+      updates.push("preset_key = ?");
+      params.push(nextPresetKey);
+      updates.push("type = ?");
+      params.push(officialPreset.type);
+      updates.push("base_url = ?");
+      params.push(officialPreset.base_url);
+
+      const mergedModels = mergeModelLists(officialPreset.fallback_models, parseModelsCache(row.models_cache));
+      if (mergedModels.length > 0) {
+        const mergedJson = JSON.stringify(mergedModels);
+        if (mergedJson !== (row.models_cache ?? "") || row.models_cached_at == null) {
+          updates.push("models_cache = ?");
+          params.push(mergedJson);
+          updates.push("models_cached_at = ?");
+          params.push(row.models_cached_at ?? now);
+        }
+      }
+    } else {
+      if ("preset_key" in body) {
+        updates.push("preset_key = ?");
+        params.push(null);
+      }
+      if ("type" in body && isApiProviderType(body.type)) {
+        updates.push("type = ?");
+        params.push(body.type);
+      }
+      if ("base_url" in body && typeof body.base_url === "string" && body.base_url.trim()) {
+        updates.push("base_url = ?");
+        params.push(body.base_url.trim().replace(/\/+$/, ""));
+      }
     }
 
     params.push(id);
@@ -240,6 +430,7 @@ export function registerApiProviderRoutes({ app, db, nowMs }: RegisterApiProvide
     const row = readProvider(db, id);
     if (!row) return sendNotFound(res);
 
+    const officialPreset = readOfficialPreset(row.preset_key)?.preset ?? null;
     const apiKey = row.api_key_enc ? decryptSecret(row.api_key_enc) : "";
     const url = buildModelsUrl(row.type, row.base_url, apiKey);
     const headers = buildApiProviderHeaders(row.type, apiKey);
@@ -255,7 +446,7 @@ export function registerApiProviderRoutes({ app, db, nowMs }: RegisterApiProvide
       }
 
       const data = await resp.json();
-      const models = extractModelIds(row.type, data);
+      const models = mergeModelLists(officialPreset?.fallback_models ?? [], extractModelIds(row.type, data));
       const now = nowMs();
       db.prepare("UPDATE api_providers SET models_cache = ?, models_cached_at = ?, updated_at = ? WHERE id = ?").run(
         JSON.stringify(models),
@@ -276,6 +467,7 @@ export function registerApiProviderRoutes({ app, db, nowMs }: RegisterApiProvide
     const row = readProvider(db, id);
     if (!row) return sendNotFound(res);
 
+    const officialPreset = readOfficialPreset(row.preset_key)?.preset ?? null;
     const cachedModels = parseModelsCache(row.models_cache);
     if (!refresh && row.models_cache) {
       return res.json({ ok: true, models: cachedModels, cached: true });
@@ -294,7 +486,7 @@ export function registerApiProviderRoutes({ app, db, nowMs }: RegisterApiProvide
         return res.status(502).json({ error: `upstream returned ${resp.status}` });
       }
       const data = await resp.json();
-      const models = extractModelIds(row.type, data);
+      const models = mergeModelLists(officialPreset?.fallback_models ?? [], extractModelIds(row.type, data));
       const now = nowMs();
       db.prepare("UPDATE api_providers SET models_cache = ?, models_cached_at = ?, updated_at = ? WHERE id = ?").run(
         JSON.stringify(models),
@@ -313,6 +505,6 @@ export function registerApiProviderRoutes({ app, db, nowMs }: RegisterApiProvide
   });
 
   app.get("/api/api-providers/presets", (_req, res) => {
-    res.json({ ok: true, presets: API_PROVIDER_PRESETS });
+    res.json({ ok: true, presets: API_PROVIDER_PRESETS, official_presets: OFFICIAL_API_PROVIDER_PRESETS });
   });
 }

--- a/server/modules/routes/ops/api-providers.ts
+++ b/server/modules/routes/ops/api-providers.ts
@@ -361,6 +361,17 @@ export function registerApiProviderRoutes({ app, db, nowMs }: RegisterApiProvide
     const existingPresetKey = existingPreset?.key ?? null;
     const incomingApiKey = "api_key" in body ? (typeof body.api_key === "string" ? body.api_key.trim() : "") : null;
     const isPresetTransition = presetKeyInput != null && presetKeyInput.presetKey !== existingPresetKey;
+    const nextManualType = "type" in body && isApiProviderType(body.type) ? body.type : row.type;
+    const nextManualBaseUrl =
+      "base_url" in body && typeof body.base_url === "string" && body.base_url.trim()
+        ? body.base_url.trim().replace(/\/+$/, "")
+        : row.base_url;
+    const nextType = officialPreset?.type ?? nextManualType;
+    const nextBaseUrl = officialPreset?.base_url ?? nextManualBaseUrl;
+    const shouldInvalidateModelCache =
+      nextPresetKey !== existingPresetKey ||
+      nextType !== row.type ||
+      normalizeApiBaseUrl(nextBaseUrl) !== normalizeApiBaseUrl(row.base_url);
 
     if ("name" in body && typeof body.name === "string" && body.name.trim()) {
       updates.push("name = ?");
@@ -389,14 +400,16 @@ export function registerApiProviderRoutes({ app, db, nowMs }: RegisterApiProvide
       updates.push("base_url = ?");
       params.push(officialPreset.base_url);
 
-      const mergedModels = mergeModelLists(officialPreset.fallback_models, parseModelsCache(row.models_cache));
+      const mergedModels = shouldInvalidateModelCache
+        ? mergeModelLists(officialPreset.fallback_models)
+        : mergeModelLists(officialPreset.fallback_models, parseModelsCache(row.models_cache));
       if (mergedModels.length > 0) {
         const mergedJson = JSON.stringify(mergedModels);
-        if (mergedJson !== (row.models_cache ?? "") || row.models_cached_at == null) {
+        if (shouldInvalidateModelCache || mergedJson !== (row.models_cache ?? "") || row.models_cached_at == null) {
           updates.push("models_cache = ?");
           params.push(mergedJson);
           updates.push("models_cached_at = ?");
-          params.push(row.models_cached_at ?? now);
+          params.push(shouldInvalidateModelCache ? now : (row.models_cached_at ?? now));
         }
       }
     } else {
@@ -411,6 +424,12 @@ export function registerApiProviderRoutes({ app, db, nowMs }: RegisterApiProvide
       if ("base_url" in body && typeof body.base_url === "string" && body.base_url.trim()) {
         updates.push("base_url = ?");
         params.push(body.base_url.trim().replace(/\/+$/, ""));
+      }
+      if (shouldInvalidateModelCache) {
+        updates.push("models_cache = ?");
+        params.push(null);
+        updates.push("models_cached_at = ?");
+        params.push(null);
       }
     }
 

--- a/server/modules/routes/ops/api-providers.ts
+++ b/server/modules/routes/ops/api-providers.ts
@@ -358,19 +358,24 @@ export function registerApiProviderRoutes({ app, db, nowMs }: RegisterApiProvide
     const updates: string[] = ["updated_at = ?"];
     const now = nowMs();
     const params: unknown[] = [now];
+    const existingPresetKey = existingPreset?.key ?? null;
+    const incomingApiKey = "api_key" in body ? (typeof body.api_key === "string" ? body.api_key.trim() : "") : null;
+    const isPresetTransition = presetKeyInput != null && presetKeyInput.presetKey !== existingPresetKey;
 
     if ("name" in body && typeof body.name === "string" && body.name.trim()) {
       updates.push("name = ?");
       params.push(body.name.trim());
     }
-    if ("api_key" in body) {
-      const apiKey = typeof body.api_key === "string" ? body.api_key.trim() : "";
-      const apiKeyError = validateOfficialPresetApiKey(officialPreset, apiKey);
+    if (officialPreset && (incomingApiKey !== null || isPresetTransition)) {
+      const retainedApiKey = row.api_key_enc ? decryptSecret(row.api_key_enc) : "";
+      const apiKeyError = validateOfficialPresetApiKey(officialPreset, incomingApiKey ?? retainedApiKey);
       if (apiKeyError) {
         return res.status(400).json({ error: apiKeyError });
       }
+    }
+    if (incomingApiKey !== null) {
       updates.push("api_key_enc = ?");
-      params.push(apiKey ? encryptSecret(apiKey) : null);
+      params.push(incomingApiKey ? encryptSecret(incomingApiKey) : null);
     }
     if ("enabled" in body) {
       updates.push("enabled = ?");

--- a/server/modules/workflow/packs/video-artifact.ts
+++ b/server/modules/workflow/packs/video-artifact.ts
@@ -18,6 +18,10 @@ const VIDEO_OUTPUT_DIR = "video_output";
 const REMOTION_OUTPUT_DIR = "out";
 const LEGACY_VIDEO_FILENAME = "final.mp4";
 
+function joinRelativePath(...segments: string[]): string {
+  return path.posix.join(...segments);
+}
+
 function normalizeSegment(raw: unknown, fallback: string): string {
   const base = String(raw ?? "").trim();
   if (!base) return fallback;
@@ -42,8 +46,8 @@ export function resolveVideoArtifactSpec(input: {
   const fileName = buildVideoArtifactFileName(input.projectName ?? null, input.departmentName ?? null);
   return {
     fileName,
-    relativePath: path.join(VIDEO_OUTPUT_DIR, fileName),
-    legacyRelativePath: path.join(VIDEO_OUTPUT_DIR, LEGACY_VIDEO_FILENAME),
+    relativePath: joinRelativePath(VIDEO_OUTPUT_DIR, fileName),
+    legacyRelativePath: joinRelativePath(VIDEO_OUTPUT_DIR, LEGACY_VIDEO_FILENAME),
   };
 }
 
@@ -109,8 +113,8 @@ export function resolveVideoArtifactRelativeCandidates(spec: VideoArtifactSpec):
     spec.relativePath,
     spec.legacyRelativePath,
     // Remotion default output directory candidates
-    path.join(REMOTION_OUTPUT_DIR, spec.fileName),
-    path.join(REMOTION_OUTPUT_DIR, LEGACY_VIDEO_FILENAME),
+    joinRelativePath(REMOTION_OUTPUT_DIR, spec.fileName),
+    joinRelativePath(REMOTION_OUTPUT_DIR, LEGACY_VIDEO_FILENAME),
   ]) {
     const normalized = String(candidate || "").trim();
     if (!normalized || seen.has(normalized)) continue;

--- a/src/api-provider-presets.test.ts
+++ b/src/api-provider-presets.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("api provider preset client", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps generic presets and official presets from the API response", async () => {
+    const fetchMock = vi.fn();
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        ok: true,
+        presets: {
+          openai: {
+            base_url: "https://api.openai.com/v1",
+            models_path: "/models",
+            auth_header: "Bearer",
+          },
+        },
+        official_presets: {
+          "opencode-go-openai": {
+            label: "OpenCode Go (OpenAI)",
+            description: "Preset",
+            type: "openai",
+            base_url: "https://opencode.ai/zen/go/v1",
+            docs_url: "https://opencode.ai/docs/ko/go/",
+            api_key_hint: "Use an OpenCode Go direct API key for this endpoint.",
+            api_key_placeholder: "sk-...",
+            fallback_models: ["glm-5", "kimi-k2.5"],
+          },
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const api = await import("./api");
+    const catalog = await api.getApiProviderPresets();
+
+    expect(catalog.presets.openai.base_url).toBe("https://api.openai.com/v1");
+    expect(catalog.official_presets["opencode-go-openai"]).toMatchObject({
+      type: "openai",
+      base_url: "https://opencode.ai/zen/go/v1",
+      fallback_models: ["glm-5", "kimi-k2.5"],
+    });
+  });
+});

--- a/src/api/providers-reports-github.ts
+++ b/src/api/providers-reports-github.ts
@@ -17,6 +17,7 @@ export interface ApiProvider {
   name: string;
   type: ApiProviderType;
   base_url: string;
+  preset_key: string | null;
   has_api_key: boolean;
   enabled: boolean;
   models_cache: string[];
@@ -31,6 +32,18 @@ export interface ApiProviderPreset {
   auth_header: string;
 }
 
+export interface ApiProviderOfficialPreset {
+  label: string;
+  description: string;
+  type: Extract<ApiProviderType, "openai" | "anthropic">;
+  base_url: string;
+  docs_url: string;
+  api_key_hint: string;
+  api_key_placeholder: string;
+  fallback_models: string[];
+  required_api_key_prefix?: string;
+}
+
 export async function getApiProviders(): Promise<ApiProvider[]> {
   const j = await request<{ ok: boolean; providers: ApiProvider[] }>("/api/api-providers");
   return j.providers;
@@ -41,6 +54,7 @@ export async function createApiProvider(input: {
   type: ApiProviderType;
   base_url: string;
   api_key?: string;
+  preset_key?: string | null;
 }): Promise<{ ok: boolean; id: string }> {
   return post("/api/api-providers", input) as Promise<{ ok: boolean; id: string }>;
 }
@@ -53,6 +67,7 @@ export async function updateApiProvider(
     base_url?: string;
     api_key?: string;
     enabled?: boolean;
+    preset_key?: string | null;
   },
 ): Promise<{ ok: boolean }> {
   return put(`/api/api-providers/${id}`, patch_data) as Promise<{ ok: boolean }>;
@@ -84,9 +99,19 @@ export async function getApiProviderModels(
   );
 }
 
-export async function getApiProviderPresets(): Promise<Record<string, ApiProviderPreset>> {
-  const j = await request<{ ok: boolean; presets: Record<string, ApiProviderPreset> }>("/api/api-providers/presets");
-  return j.presets;
+export async function getApiProviderPresets(): Promise<{
+  presets: Record<ApiProviderType, ApiProviderPreset>;
+  official_presets: Record<string, ApiProviderOfficialPreset>;
+}> {
+  const j = await request<{
+    ok: boolean;
+    presets: Record<ApiProviderType, ApiProviderPreset>;
+    official_presets: Record<string, ApiProviderOfficialPreset>;
+  }>("/api/api-providers/presets");
+  return {
+    presets: j.presets,
+    official_presets: j.official_presets ?? {},
+  };
 }
 
 // ── Task Reports ─────────────────────────────────────────────────────────────

--- a/src/components/settings/ApiSettingsTab.test.tsx
+++ b/src/components/settings/ApiSettingsTab.test.tsx
@@ -27,12 +27,12 @@ const OFFICIAL_PRESETS = {
     fallback_models: ["glm-5", "kimi-k2.5"],
   },
   "alibaba-coding-plan-openai": {
-    label: "Alibaba Coding Plan (OpenAI)",
-    description: "Alibaba Cloud Coding Plan direct API preset using the OpenAI-compatible protocol.",
+    label: "Bailian Coding Plan (OpenAI)",
+    description: "Alibaba Bailian Coding Plan direct API preset using the OpenAI-compatible protocol.",
     type: "openai" as const,
     base_url: "https://coding-intl.dashscope.aliyuncs.com/v1",
     docs_url: "https://www.alibabacloud.com/help/en/model-studio/other-tools-coding-plan",
-    api_key_hint: "Coding Plan keys for this preset must start with sk-sp-.",
+    api_key_hint: "Bailian Coding Plan keys for this preset must start with sk-sp-.",
     api_key_placeholder: "sk-sp-...",
     fallback_models: ["qwen3.5-plus", "glm-5"],
     required_api_key_prefix: "sk-sp-",
@@ -128,7 +128,7 @@ describe("ApiSettingsTab", () => {
         providers={[
           {
             id: "provider-1",
-            name: "Alibaba Coding Plan",
+            name: "Bailian Coding Plan",
             type: "openai",
             base_url: "https://coding-intl.dashscope.aliyuncs.com/v1",
             preset_key: "alibaba-coding-plan-openai",
@@ -143,7 +143,7 @@ describe("ApiSettingsTab", () => {
       />,
     );
 
-    expect(screen.getByText("Alibaba Coding Plan (OpenAI)")).toBeInTheDocument();
+    expect(screen.getByText("Bailian Coding Plan (OpenAI)")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /Models \(2\)/ }));
     expect(screen.getByText("qwen3.5-plus")).toBeInTheDocument();
     expect(screen.getByText("glm-5")).toBeInTheDocument();

--- a/src/components/settings/ApiSettingsTab.test.tsx
+++ b/src/components/settings/ApiSettingsTab.test.tsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { ApiProvider } from "../../api";
+import type { ApiAssignTarget, ApiFormState, ApiStateBundle } from "./types";
+import ApiSettingsTab from "./ApiSettingsTab";
+import { DEFAULT_API_FORM } from "./useApiProvidersState";
+
+vi.mock("./ApiAssignModal", () => ({
+  default: () => null,
+}));
+
+function t(messages: Record<string, string>): string {
+  return messages.en ?? messages.ko ?? messages.ja ?? messages.zh ?? Object.values(messages)[0] ?? "";
+}
+
+const OFFICIAL_PRESETS = {
+  "opencode-go-openai": {
+    label: "OpenCode Go (OpenAI)",
+    description: "OpenCode Go direct API preset using the OpenAI-compatible protocol.",
+    type: "openai" as const,
+    base_url: "https://opencode.ai/zen/go/v1",
+    docs_url: "https://opencode.ai/docs/ko/go/",
+    api_key_hint: "Use an OpenCode Go direct API key for this endpoint.",
+    api_key_placeholder: "sk-...",
+    fallback_models: ["glm-5", "kimi-k2.5"],
+  },
+  "alibaba-coding-plan-openai": {
+    label: "Alibaba Coding Plan (OpenAI)",
+    description: "Alibaba Cloud Coding Plan direct API preset using the OpenAI-compatible protocol.",
+    type: "openai" as const,
+    base_url: "https://coding-intl.dashscope.aliyuncs.com/v1",
+    docs_url: "https://www.alibabacloud.com/help/en/model-studio/other-tools-coding-plan",
+    api_key_hint: "Coding Plan keys for this preset must start with sk-sp-.",
+    api_key_placeholder: "sk-sp-...",
+    fallback_models: ["qwen3.5-plus", "glm-5"],
+    required_api_key_prefix: "sk-sp-",
+  },
+};
+
+function TestHarness({ providers = [], addMode = true }: { providers?: ApiProvider[]; addMode?: boolean }) {
+  const [apiAddMode, setApiAddMode] = useState(addMode);
+  const [apiEditingId, setApiEditingId] = useState<string | null>(null);
+  const [apiForm, setApiForm] = useState<ApiFormState>(DEFAULT_API_FORM);
+  const [apiSaveError, setApiSaveError] = useState<string | null>(null);
+  const [apiModelsExpanded, setApiModelsExpanded] = useState<Record<string, boolean>>({});
+  const [apiAssignTarget, setApiAssignTarget] = useState<ApiAssignTarget | null>(null);
+
+  const apiState: ApiStateBundle = {
+    apiProviders: providers,
+    apiProvidersLoading: false,
+    apiOfficialPresets: OFFICIAL_PRESETS,
+    apiPresetsLoading: false,
+    apiAddMode,
+    apiEditingId,
+    apiForm,
+    apiSaving: false,
+    apiSaveError,
+    apiTesting: null,
+    apiTestResult: {},
+    apiModelsExpanded,
+    apiAssignTarget,
+    apiAssignAgents: [],
+    apiAssignDepts: [],
+    apiAssigning: false,
+    setApiAddMode,
+    setApiEditingId,
+    setApiForm,
+    setApiSaveError,
+    setApiModelsExpanded,
+    setApiAssignTarget,
+    loadApiProviders: async () => {},
+    handleApiProviderSave: async () => {},
+    handleApiProviderDelete: async () => {},
+    handleApiProviderTest: async () => {},
+    handleApiProviderToggle: async () => {},
+    handleApiEditStart: (provider) => {
+      setApiEditingId(provider.id);
+      setApiAddMode(true);
+      setApiForm({
+        name: provider.name,
+        type: provider.type,
+        base_url: provider.base_url,
+        api_key: "",
+        preset_key: provider.preset_key,
+      });
+    },
+    handleApiModelAssign: async () => {},
+    handleApiAssignToAgent: async () => {},
+  };
+
+  return <ApiSettingsTab t={t} localeTag="en-US" apiState={apiState} />;
+}
+
+describe("ApiSettingsTab", () => {
+  it("applies official preset values and locks Base URL editing", async () => {
+    const user = userEvent.setup();
+    render(<TestHarness />);
+
+    await user.click(screen.getByRole("button", { name: /OpenCode Go \(OpenAI\)/ }));
+
+    expect(screen.getByDisplayValue("OpenCode Go (OpenAI)")).toBeInTheDocument();
+    const baseUrlInput = screen.getByPlaceholderText("https://api.openai.com/v1") as HTMLInputElement;
+    expect(baseUrlInput.value).toBe("https://opencode.ai/zen/go/v1");
+    expect(baseUrlInput.readOnly).toBe(true);
+    expect(screen.getByText("glm-5")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open docs" })).toHaveAttribute("href", "https://opencode.ai/docs/ko/go/");
+  });
+
+  it("unlocks manual editing when switching back to a generic type", async () => {
+    const user = userEvent.setup();
+    render(<TestHarness />);
+
+    await user.click(screen.getByRole("button", { name: /OpenCode Go \(OpenAI\)/ }));
+    await user.click(screen.getByRole("button", { name: "Custom" }));
+
+    const baseUrlInput = screen.getByPlaceholderText("https://api.openai.com/v1") as HTMLInputElement;
+    expect(baseUrlInput.readOnly).toBe(false);
+    expect(screen.getByDisplayValue("Custom")).toBeInTheDocument();
+  });
+
+  it("shows preset badge and seeded models on provider cards", async () => {
+    const user = userEvent.setup();
+    render(
+      <TestHarness
+        addMode={false}
+        providers={[
+          {
+            id: "provider-1",
+            name: "Alibaba Coding Plan",
+            type: "openai",
+            base_url: "https://coding-intl.dashscope.aliyuncs.com/v1",
+            preset_key: "alibaba-coding-plan-openai",
+            has_api_key: true,
+            enabled: true,
+            models_cache: ["qwen3.5-plus", "glm-5"],
+            models_cached_at: 1_717_171_717_000,
+            created_at: 1_717_171_717_000,
+            updated_at: 1_717_171_717_000,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Alibaba Coding Plan (OpenAI)")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Models \(2\)/ }));
+    expect(screen.getByText("qwen3.5-plus")).toBeInTheDocument();
+    expect(screen.getByText("glm-5")).toBeInTheDocument();
+  });
+});

--- a/src/components/settings/ApiSettingsTab.test.tsx
+++ b/src/components/settings/ApiSettingsTab.test.tsx
@@ -71,6 +71,7 @@ function TestHarness({ providers = [], addMode = true }: { providers?: ApiProvid
     setApiModelsExpanded,
     setApiAssignTarget,
     loadApiProviders: async () => {},
+    loadApiPresets: async () => {},
     handleApiProviderSave: async () => {},
     handleApiProviderDelete: async () => {},
     handleApiProviderTest: async () => {},
@@ -147,5 +148,64 @@ describe("ApiSettingsTab", () => {
     await user.click(screen.getByRole("button", { name: /Models \(2\)/ }));
     expect(screen.getByText("qwen3.5-plus")).toBeInTheDocument();
     expect(screen.getByText("glm-5")).toBeInTheDocument();
+  });
+
+  it("retries presets through the refresh button instead of auto-looping silently", async () => {
+    const user = userEvent.setup();
+    const loadApiProviders = vi.fn(async () => {});
+    const loadApiPresets = vi.fn(async () => {});
+    const apiAddMode = false;
+    const setApiAddMode = vi.fn();
+    const apiEditingId = null;
+    const setApiEditingId = vi.fn();
+    const apiForm = DEFAULT_API_FORM;
+    const setApiForm = vi.fn();
+    const apiSaveError = "load failed";
+    const setApiSaveError = vi.fn();
+    const apiModelsExpanded = {};
+    const setApiModelsExpanded = vi.fn();
+    const apiAssignTarget = null;
+    const setApiAssignTarget = vi.fn();
+
+    const apiState: ApiStateBundle = {
+      apiProviders: [],
+      apiProvidersLoading: false,
+      apiOfficialPresets: {},
+      apiPresetsLoading: false,
+      apiAddMode,
+      apiEditingId,
+      apiForm,
+      apiSaving: false,
+      apiSaveError,
+      apiTesting: null,
+      apiTestResult: {},
+      apiModelsExpanded,
+      apiAssignTarget,
+      apiAssignAgents: [],
+      apiAssignDepts: [],
+      apiAssigning: false,
+      setApiAddMode,
+      setApiEditingId,
+      setApiForm,
+      setApiSaveError,
+      setApiModelsExpanded,
+      setApiAssignTarget,
+      loadApiProviders,
+      loadApiPresets,
+      handleApiProviderSave: async () => {},
+      handleApiProviderDelete: async () => {},
+      handleApiProviderTest: async () => {},
+      handleApiProviderToggle: async () => {},
+      handleApiEditStart: () => {},
+      handleApiModelAssign: async () => {},
+      handleApiAssignToAgent: async () => {},
+    };
+
+    render(<ApiSettingsTab t={t} localeTag="en-US" apiState={apiState} />);
+
+    await user.click(screen.getByRole("button", { name: "Refresh" }));
+
+    expect(loadApiProviders).toHaveBeenCalledTimes(1);
+    expect(loadApiPresets).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/settings/ApiSettingsTab.tsx
+++ b/src/components/settings/ApiSettingsTab.tsx
@@ -13,16 +13,20 @@ export default function ApiSettingsTab({ t, localeTag, apiState }: ApiSettingsTa
   const {
     apiProviders,
     apiProvidersLoading,
+    apiOfficialPresets,
+    apiPresetsLoading,
     apiAddMode,
     apiEditingId,
     apiForm,
     apiSaving,
+    apiSaveError,
     apiTesting,
     apiTestResult,
     apiModelsExpanded,
     setApiAddMode,
     setApiEditingId,
     setApiForm,
+    setApiSaveError,
     setApiModelsExpanded,
     loadApiProviders,
     handleApiProviderSave,
@@ -33,29 +37,42 @@ export default function ApiSettingsTab({ t, localeTag, apiState }: ApiSettingsTa
     handleApiModelAssign,
   } = apiState;
 
+  const selectedOfficialPreset = apiForm.preset_key ? apiOfficialPresets[apiForm.preset_key] : null;
+  const isOfficialPresetSelected = Boolean(apiForm.preset_key);
+
+  function resetForm(): void {
+    setApiAddMode(false);
+    setApiEditingId(null);
+    setApiSaveError(null);
+    setApiForm(DEFAULT_API_FORM);
+  }
+
+  function openAddMode(): void {
+    setApiAddMode(true);
+    setApiEditingId(null);
+    setApiSaveError(null);
+    setApiForm(DEFAULT_API_FORM);
+  }
+
   return (
     <>
       <section className="space-y-4 rounded-xl border border-slate-700/50 bg-slate-800/60 p-4 sm:p-5">
         <div className="flex items-center justify-between">
-          <h3 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">
-            {t({ ko: "API 프로바이더", en: "API Providers", ja: "API プロバイダー", zh: "API 提供商" })}
+          <h3 className="text-sm font-semibold uppercase tracking-wider text-slate-300">
+            {t({ ko: "API 프로바이더", en: "API Providers", ja: "API プロバイダー", zh: "API 提供方" })}
           </h3>
           <div className="flex items-center gap-2">
             <button
               onClick={() => void loadApiProviders()}
               disabled={apiProvidersLoading}
-              className="text-xs text-blue-400 hover:text-blue-300 transition-colors disabled:opacity-50"
+              className="text-xs text-blue-400 transition-colors hover:text-blue-300 disabled:opacity-50"
             >
-              🔄 {t({ ko: "새로고침", en: "Refresh", ja: "更新", zh: "刷新" })}
+              {t({ ko: "새로고침", en: "Refresh", ja: "更新", zh: "刷新" })}
             </button>
             {!apiAddMode && (
               <button
-                onClick={() => {
-                  setApiAddMode(true);
-                  setApiEditingId(null);
-                  setApiForm(DEFAULT_API_FORM);
-                }}
-                className="text-xs px-3 py-1 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white font-medium transition-colors"
+                onClick={openAddMode}
+                className="rounded-lg bg-emerald-600 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-emerald-500"
               >
                 + {t({ ko: "추가", en: "Add", ja: "追加", zh: "添加" })}
               </button>
@@ -65,51 +82,160 @@ export default function ApiSettingsTab({ t, localeTag, apiState }: ApiSettingsTa
 
         <p className="text-xs text-slate-500">
           {t({
-            ko: "로컬 모델(Ollama 등), 프론티어 모델(OpenAI, Anthropic 등), 기타 서비스의 API를 등록하여 언어모델에 접근합니다.",
-            en: "Register APIs for local models (Ollama, etc.), frontier models (OpenAI, Anthropic, etc.), and other services.",
-            ja: "ローカルモデル（Ollama等）、フロンティアモデル（OpenAI, Anthropic等）、その他サービスのAPIを登録します。",
-            zh: "注册本地模型（Ollama等）、前沿模型（OpenAI、Anthropic等）及其他服务的API。",
+            ko: "로컬 모델, 프론티어 모델, 기타 호환 서비스용 API를 등록해 에이전트에 직접 연결할 수 있습니다.",
+            en: "Register local, frontier, and compatible third-party APIs, then assign those models directly to agents.",
+            ja: "ローカルモデルや先端モデル、互換サービスの API を登録してエージェントへ直接割り当てられます。",
+            zh: "可注册本地模型、前沿模型和兼容第三方服务的 API，并将模型直接分配给代理。",
           })}
         </p>
 
         {apiAddMode && (
-          <div className="space-y-3 border border-blue-500/30 rounded-lg p-4 bg-slate-900/50">
-            <h4 className="text-xs font-semibold text-blue-400 uppercase">
+          <div className="space-y-3 rounded-lg border border-blue-500/30 bg-slate-900/50 p-4">
+            <h4 className="text-xs font-semibold uppercase text-blue-400">
               {apiEditingId
-                ? t({ ko: "프로바이더 수정", en: "Edit Provider", ja: "プロバイダー編集", zh: "编辑提供商" })
+                ? t({ ko: "프로바이더 수정", en: "Edit Provider", ja: "プロバイダー編集", zh: "编辑提供方" })
                 : t({
                     ko: "새 프로바이더 추가",
                     en: "Add New Provider",
-                    ja: "新規プロバイダー追加",
-                    zh: "添加新提供商",
+                    ja: "新しいプロバイダーを追加",
+                    zh: "添加新提供方",
                   })}
             </h4>
 
             <div>
-              <label className="block text-xs text-slate-400 mb-1">
-                {t({ ko: "유형", en: "Type", ja: "タイプ", zh: "类型" })}
+              <label className="mb-1 block text-xs text-slate-400">
+                {t({ ko: "공식 프리셋", en: "Official Presets", ja: "公式プリセット", zh: "官方预设" })}
               </label>
+              <p className="mb-2 text-[11px] text-slate-500">
+                {t({
+                  ko: "OpenCode Go와 Alibaba Coding Plan용 공식 프리셋입니다.",
+                  en: "Official presets for OpenCode Go and Alibaba Coding Plan.",
+                  ja: "OpenCode Go と Alibaba Coding Plan 向けの公式プリセットです。",
+                  zh: "适用于 OpenCode Go 与 Alibaba Coding Plan 的官方预设。",
+                })}
+              </p>
+
+              {apiPresetsLoading ? (
+                <div className="rounded-lg border border-slate-700/40 bg-slate-900/40 px-3 py-2 text-[11px] text-slate-500">
+                  {t({
+                    ko: "프리셋 불러오는 중...",
+                    en: "Loading presets...",
+                    ja: "プリセットを読み込み中...",
+                    zh: "正在加载预设...",
+                  })}
+                </div>
+              ) : Object.keys(apiOfficialPresets).length === 0 ? (
+                <div className="rounded-lg border border-slate-700/40 bg-slate-900/40 px-3 py-2 text-[11px] text-slate-500">
+                  {t({
+                    ko: "공식 프리셋을 불러오지 못했습니다.",
+                    en: "Official presets could not be loaded.",
+                    ja: "公式プリセットを読み込めませんでした。",
+                    zh: "无法加载官方预设。",
+                  })}
+                </div>
+              ) : (
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {Object.entries(apiOfficialPresets).map(([key, preset]) => (
+                    <button
+                      key={key}
+                      onClick={() => {
+                        setApiSaveError(null);
+                        setApiForm((prev) => ({
+                          ...prev,
+                          preset_key: key,
+                          name: preset.label,
+                          type: preset.type,
+                          base_url: preset.base_url,
+                        }));
+                      }}
+                      className={`rounded-lg border px-3 py-2 text-left transition-colors ${
+                        apiForm.preset_key === key
+                          ? "border-blue-500/60 bg-blue-600/15"
+                          : "border-slate-700/40 bg-slate-900/40 hover:border-slate-500/60 hover:bg-slate-800/60"
+                      }`}
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="text-xs font-semibold text-white">{preset.label}</span>
+                        <span className="rounded bg-slate-800/70 px-1.5 py-0.5 text-[10px] uppercase text-slate-400">
+                          {preset.type}
+                        </span>
+                      </div>
+                      <div className="mt-1 text-[11px] text-slate-400">{preset.description}</div>
+                      <div className="mt-1 font-mono text-[10px] text-slate-500">{preset.base_url}</div>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {selectedOfficialPreset && (
+              <div className="rounded-lg border border-blue-500/30 bg-blue-950/20 p-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="text-xs font-semibold text-blue-300">{selectedOfficialPreset.label}</div>
+                  <a
+                    href={selectedOfficialPreset.docs_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-[11px] text-blue-400 hover:text-blue-300"
+                  >
+                    {t({ ko: "문서 열기", en: "Open docs", ja: "ドキュメントを開く", zh: "打开文档" })}
+                  </a>
+                </div>
+                <div className="mt-2 text-[11px] text-slate-300">{selectedOfficialPreset.api_key_hint}</div>
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {selectedOfficialPreset.fallback_models.map((model) => (
+                    <span
+                      key={model}
+                      className="rounded-full border border-blue-500/20 bg-slate-950/40 px-2 py-0.5 text-[10px] font-mono text-blue-200"
+                    >
+                      {model}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div>
+              <label className="mb-1 block text-xs text-slate-400">
+                {t({ ko: "일반 타입", en: "Generic Type", ja: "汎用タイプ", zh: "通用类型" })}
+              </label>
+              <p className="mb-2 text-[11px] text-slate-500">
+                {isOfficialPresetSelected
+                  ? t({
+                      ko: "일반 타입을 선택하면 프리셋 잠금이 해제됩니다.",
+                      en: "Choose a generic type to leave preset mode and unlock manual editing.",
+                      ja: "汎用タイプを選ぶとプリセット固定が解除されます。",
+                      zh: "选择通用类型即可退出预设模式并解锁手动编辑。",
+                    })
+                  : t({
+                      ko: "프로토콜과 Base URL을 직접 설정하려면 일반 타입을 사용하세요.",
+                      en: "Use a generic type when you want to manage protocol and Base URL yourself.",
+                      ja: "プロトコルと Base URL を手動設定する場合は汎用タイプを使います。",
+                      zh: "如果要自己管理协议与 Base URL，请使用通用类型。",
+                    })}
+              </p>
               <div className="flex flex-wrap gap-1.5">
                 {(
-                  Object.entries(API_TYPE_PRESETS) as [
-                    keyof typeof API_TYPE_PRESETS,
-                    { label: string; base_url: string },
-                  ][]
-                )?.map(([key, preset]) => (
+                  Object.entries(API_TYPE_PRESETS) as Array<
+                    [keyof typeof API_TYPE_PRESETS, { label: string; base_url: string }]
+                  >
+                ).map(([key, preset]) => (
                   <button
                     key={key}
                     onClick={() => {
+                      setApiSaveError(null);
                       setApiForm((prev) => ({
                         ...prev,
+                        preset_key: null,
                         type: key,
                         base_url: preset.base_url || prev.base_url,
-                        name: prev.name || preset.label,
+                        name: prev.preset_key ? preset.label : prev.name || preset.label,
                       }));
                     }}
-                    className={`px-2.5 py-1 text-[11px] rounded-md border transition-colors ${
-                      apiForm.type === key
-                        ? "bg-blue-600/30 border-blue-500/50 text-blue-300"
-                        : "bg-slate-700/30 border-slate-600/30 text-slate-400 hover:text-slate-200 hover:border-slate-500/50"
+                    className={`rounded-md border px-2.5 py-1 text-[11px] transition-colors ${
+                      !apiForm.preset_key && apiForm.type === key
+                        ? "border-blue-500/50 bg-blue-600/30 text-blue-300"
+                        : "border-slate-600/30 bg-slate-700/30 text-slate-400 hover:border-slate-500/50 hover:text-slate-200"
                     }`}
                   >
                     {preset.label}
@@ -119,40 +245,66 @@ export default function ApiSettingsTab({ t, localeTag, apiState }: ApiSettingsTa
             </div>
 
             <div>
-              <label className="block text-xs text-slate-400 mb-1">
+              <label className="mb-1 block text-xs text-slate-400">
                 {t({ ko: "이름", en: "Name", ja: "名前", zh: "名称" })}
               </label>
               <input
                 type="text"
                 value={apiForm.name}
-                onChange={(e) => setApiForm((prev) => ({ ...prev, name: e.target.value }))}
-                placeholder={t({ ko: "예: My OpenAI", en: "e.g. My OpenAI", ja: "例: My OpenAI", zh: "如: My OpenAI" })}
-                className="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-white text-sm focus:outline-none focus:border-blue-500"
+                onChange={(e) => {
+                  setApiSaveError(null);
+                  setApiForm((prev) => ({ ...prev, name: e.target.value }));
+                }}
+                placeholder={t({
+                  ko: "예: My OpenAI",
+                  en: "e.g. My OpenAI",
+                  ja: "例: My OpenAI",
+                  zh: "例如：My OpenAI",
+                })}
+                className="w-full rounded-lg border border-slate-600 bg-slate-700/50 px-3 py-2 text-sm text-white focus:border-blue-500 focus:outline-none"
               />
             </div>
 
             <div>
-              <label className="block text-xs text-slate-400 mb-1">Base URL</label>
+              <label className="mb-1 block text-xs text-slate-400">Base URL</label>
               <input
                 type="text"
                 value={apiForm.base_url}
-                onChange={(e) => setApiForm((prev) => ({ ...prev, base_url: e.target.value }))}
+                onChange={(e) => {
+                  setApiSaveError(null);
+                  setApiForm((prev) => ({ ...prev, base_url: e.target.value }));
+                }}
                 placeholder="https://api.openai.com/v1"
-                className="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-white text-sm font-mono focus:outline-none focus:border-blue-500"
+                readOnly={isOfficialPresetSelected}
+                className={`w-full rounded-lg border px-3 py-2 text-sm font-mono text-white focus:border-blue-500 focus:outline-none ${
+                  isOfficialPresetSelected
+                    ? "border-blue-500/20 bg-slate-800/70 text-slate-300"
+                    : "border-slate-600 bg-slate-700/50"
+                }`}
               />
+              {isOfficialPresetSelected && (
+                <p className="mt-1 text-[11px] text-slate-500">
+                  {t({
+                    ko: "선택한 프리셋이 프로토콜과 Base URL을 관리합니다.",
+                    en: "The selected preset manages the protocol and Base URL.",
+                    ja: "選択したプリセットがプロトコルと Base URL を管理します。",
+                    zh: "所选预设会管理协议与 Base URL。",
+                  })}
+                </p>
+              )}
             </div>
 
             <div>
-              <label className="block text-xs text-slate-400 mb-1">
+              <label className="mb-1 block text-xs text-slate-400">
                 API Key{" "}
-                {apiForm.type === "ollama" && (
+                {!selectedOfficialPreset && apiForm.type === "ollama" && (
                   <span className="text-slate-600">
                     (
                     {t({
-                      ko: "로컬은 보통 불필요",
+                      ko: "로컬 환경에서는 보통 필요하지 않음",
                       en: "usually not needed for local",
-                      ja: "ローカルは通常不要",
-                      zh: "本地通常不需要",
+                      ja: "ローカルでは通常不要",
+                      zh: "本地环境通常不需要",
                     })}
                     )
                   </span>
@@ -161,26 +313,38 @@ export default function ApiSettingsTab({ t, localeTag, apiState }: ApiSettingsTa
               <input
                 type="password"
                 value={apiForm.api_key}
-                onChange={(e) => setApiForm((prev) => ({ ...prev, api_key: e.target.value }))}
+                onChange={(e) => {
+                  setApiSaveError(null);
+                  setApiForm((prev) => ({ ...prev, api_key: e.target.value }));
+                }}
                 placeholder={
                   apiEditingId
                     ? t({
-                        ko: "변경하려면 입력 (빈칸=유지)",
+                        ko: "변경하려면 입력 (빈값=유지)",
                         en: "Enter to change (blank=keep)",
-                        ja: "変更する場合は入力",
-                        zh: "输入以更改（空白=保持）",
+                        ja: "変更する場合のみ入力 (空欄=維持)",
+                        zh: "仅在修改时输入（留空=保持）",
                       })
-                    : "sk-..."
+                    : (selectedOfficialPreset?.api_key_placeholder ?? "sk-...")
                 }
-                className="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-white text-sm font-mono focus:outline-none focus:border-blue-500"
+                className="w-full rounded-lg border border-slate-600 bg-slate-700/50 px-3 py-2 text-sm font-mono text-white focus:border-blue-500 focus:outline-none"
               />
+              {selectedOfficialPreset && (
+                <p className="mt-1 text-[11px] text-slate-500">{selectedOfficialPreset.api_key_hint}</p>
+              )}
             </div>
+
+            {apiSaveError && (
+              <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-[11px] text-red-300">
+                {apiSaveError}
+              </div>
+            )}
 
             <div className="flex items-center gap-2">
               <button
                 onClick={() => void handleApiProviderSave()}
                 disabled={apiSaving || !apiForm.name.trim() || !apiForm.base_url.trim()}
-                className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-xs font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="rounded-lg bg-blue-600 px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {apiSaving
                   ? t({ ko: "저장 중...", en: "Saving...", ja: "保存中...", zh: "保存中..." })
@@ -189,12 +353,8 @@ export default function ApiSettingsTab({ t, localeTag, apiState }: ApiSettingsTa
                     : t({ ko: "추가", en: "Add", ja: "追加", zh: "添加" })}
               </button>
               <button
-                onClick={() => {
-                  setApiAddMode(false);
-                  setApiEditingId(null);
-                  setApiForm(DEFAULT_API_FORM);
-                }}
-                className="px-4 py-2 bg-slate-700 hover:bg-slate-600 text-slate-300 text-xs font-medium rounded-lg transition-colors"
+                onClick={resetForm}
+                className="rounded-lg bg-slate-700 px-4 py-2 text-xs font-medium text-slate-300 transition-colors hover:bg-slate-600"
               >
                 {t({ ko: "취소", en: "Cancel", ja: "キャンセル", zh: "取消" })}
               </button>
@@ -203,16 +363,16 @@ export default function ApiSettingsTab({ t, localeTag, apiState }: ApiSettingsTa
         )}
 
         {apiProvidersLoading ? (
-          <div className="text-xs text-slate-500 animate-pulse py-4 text-center">
-            {t({ ko: "로딩 중...", en: "Loading...", ja: "読み込み中...", zh: "加载中..." })}
+          <div className="animate-pulse py-4 text-center text-xs text-slate-500">
+            {t({ ko: "불러오는 중...", en: "Loading...", ja: "読み込み中...", zh: "加载中..." })}
           </div>
         ) : apiProviders.length === 0 && !apiAddMode ? (
-          <div className="text-xs text-slate-500 py-6 text-center">
+          <div className="py-6 text-center text-xs text-slate-500">
             {t({
               ko: "등록된 API 프로바이더가 없습니다. 위의 + 추가 버튼으로 시작하세요.",
               en: "No API providers registered. Click + Add above to get started.",
-              ja: "APIプロバイダーが登録されていません。上の+追加ボタンから始めてください。",
-              zh: "没有已注册的API提供商。点击上方的+添加按钮开始。",
+              ja: "API プロバイダーがありません。上の + Add から始めてください。",
+              zh: "还没有注册 API 提供方。点击上方的 + Add 开始。",
             })}
           </div>
         ) : (
@@ -220,6 +380,10 @@ export default function ApiSettingsTab({ t, localeTag, apiState }: ApiSettingsTa
             {apiProviders.map((provider) => {
               const testResult = apiTestResult[provider.id];
               const isExpanded = apiModelsExpanded[provider.id];
+              const presetLabel = provider.preset_key
+                ? (apiOfficialPresets[provider.preset_key]?.label ?? provider.preset_key)
+                : null;
+
               return (
                 <div
                   key={provider.id}
@@ -230,39 +394,45 @@ export default function ApiSettingsTab({ t, localeTag, apiState }: ApiSettingsTa
                   }`}
                 >
                   <div className="flex items-center justify-between gap-2">
-                    <div className="flex items-center gap-2 min-w-0">
+                    <div className="flex min-w-0 items-center gap-2">
                       <span
-                        className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${
+                        className={`inline-block h-2 w-2 flex-shrink-0 rounded-full ${
                           provider.enabled ? "bg-emerald-400" : "bg-slate-600"
                         }`}
                       />
-                      <span className="text-sm font-medium text-white truncate">{provider.name}</span>
-                      <span className="text-[10px] px-1.5 py-0.5 rounded bg-slate-700/50 text-slate-400 uppercase flex-shrink-0">
+                      <span className="truncate text-sm font-medium text-white">{provider.name}</span>
+                      <span className="flex-shrink-0 rounded bg-slate-700/50 px-1.5 py-0.5 text-[10px] uppercase text-slate-400">
                         {provider.type}
                       </span>
-                      {provider.has_api_key && <span className="text-[10px] text-emerald-400 flex-shrink-0">🔑</span>}
+                      {presetLabel && (
+                        <span className="flex-shrink-0 rounded border border-blue-500/20 bg-blue-600/20 px-1.5 py-0.5 text-[10px] text-blue-300">
+                          {presetLabel}
+                        </span>
+                      )}
+                      {provider.has_api_key && <span className="flex-shrink-0 text-[10px] text-emerald-400">key</span>}
                     </div>
-                    <div className="flex items-center gap-1.5 flex-shrink-0">
+
+                    <div className="flex flex-shrink-0 items-center gap-1.5">
                       <button
                         onClick={() => void handleApiProviderTest(provider.id)}
                         disabled={apiTesting === provider.id}
-                        className="text-[10px] px-2 py-1 rounded bg-cyan-600/20 text-cyan-400 border border-cyan-500/30 hover:bg-cyan-600/30 transition-colors disabled:opacity-50"
-                        title={t({ ko: "연결 테스트", en: "Test Connection", ja: "接続テスト", zh: "测试连接" })}
+                        className="rounded border border-cyan-500/30 bg-cyan-600/20 px-2 py-1 text-[10px] text-cyan-400 transition-colors hover:bg-cyan-600/30 disabled:opacity-50"
+                        title={t({ ko: "연결 테스트", en: "Test Connection", ja: "接続テスト", zh: "连接测试" })}
                       >
                         {apiTesting === provider.id ? "..." : t({ ko: "테스트", en: "Test", ja: "テスト", zh: "测试" })}
                       </button>
                       <button
                         onClick={() => handleApiEditStart(provider)}
-                        className="text-[10px] px-2 py-1 rounded bg-slate-600/30 text-slate-400 border border-slate-500/30 hover:bg-slate-600/50 hover:text-slate-200 transition-colors"
+                        className="rounded border border-slate-500/30 bg-slate-600/30 px-2 py-1 text-[10px] text-slate-400 transition-colors hover:bg-slate-600/50 hover:text-slate-200"
                       >
                         {t({ ko: "수정", en: "Edit", ja: "編集", zh: "编辑" })}
                       </button>
                       <button
                         onClick={() => void handleApiProviderToggle(provider.id, provider.enabled)}
-                        className={`text-[10px] px-2 py-1 rounded border transition-colors ${
+                        className={`rounded border px-2 py-1 text-[10px] transition-colors ${
                           provider.enabled
-                            ? "bg-amber-600/20 text-amber-400 border-amber-500/30 hover:bg-amber-600/30"
-                            : "bg-emerald-600/20 text-emerald-400 border-emerald-500/30 hover:bg-emerald-600/30"
+                            ? "border-amber-500/30 bg-amber-600/20 text-amber-400 hover:bg-amber-600/30"
+                            : "border-emerald-500/30 bg-emerald-600/20 text-emerald-400 hover:bg-emerald-600/30"
                         }`}
                       >
                         {provider.enabled
@@ -271,24 +441,23 @@ export default function ApiSettingsTab({ t, localeTag, apiState }: ApiSettingsTa
                       </button>
                       <button
                         onClick={() => void handleApiProviderDelete(provider.id)}
-                        className="text-[10px] px-2 py-1 rounded bg-red-600/20 text-red-400 border border-red-500/30 hover:bg-red-600/30 transition-colors"
+                        className="rounded border border-red-500/30 bg-red-600/20 px-2 py-1 text-[10px] text-red-400 transition-colors hover:bg-red-600/30"
                       >
                         {t({ ko: "삭제", en: "Delete", ja: "削除", zh: "删除" })}
                       </button>
                     </div>
                   </div>
 
-                  <div className="mt-1.5 text-[11px] font-mono text-slate-500 truncate">{provider.base_url}</div>
+                  <div className="mt-1.5 truncate text-[11px] font-mono text-slate-500">{provider.base_url}</div>
 
                   {testResult && (
                     <div
-                      className={`mt-2 text-[11px] px-2.5 py-1.5 rounded ${
+                      className={`mt-2 rounded px-2.5 py-1.5 text-[11px] ${
                         testResult.ok
-                          ? "bg-green-500/10 text-green-400 border border-green-500/20"
-                          : "bg-red-500/10 text-red-400 border border-red-500/20"
+                          ? "border border-green-500/20 bg-green-500/10 text-green-400"
+                          : "border border-red-500/20 bg-red-500/10 text-red-400"
                       }`}
                     >
-                      {testResult.ok ? "✓ " : "✗ "}
                       {testResult.msg}
                     </div>
                   )}
@@ -297,14 +466,13 @@ export default function ApiSettingsTab({ t, localeTag, apiState }: ApiSettingsTa
                     <div className="mt-2">
                       <button
                         onClick={() => setApiModelsExpanded((prev) => ({ ...prev, [provider.id]: !prev[provider.id] }))}
-                        className="text-[11px] text-slate-400 hover:text-slate-200 transition-colors"
+                        className="text-[11px] text-slate-400 transition-colors hover:text-slate-200"
                       >
-                        {isExpanded ? "▼" : "▶"}{" "}
+                        {isExpanded ? "-" : "+"}{" "}
                         {t({ ko: "모델 목록", en: "Models", ja: "モデル一覧", zh: "模型列表" })} (
                         {provider.models_cache.length})
                         {provider.models_cached_at && (
-                          <span className="text-slate-600 ml-1">
-                            ·{" "}
+                          <span className="ml-1 text-slate-600">
                             {new Date(provider.models_cached_at).toLocaleString(localeTag, {
                               hour: "2-digit",
                               minute: "2-digit",
@@ -312,17 +480,18 @@ export default function ApiSettingsTab({ t, localeTag, apiState }: ApiSettingsTa
                           </span>
                         )}
                       </button>
+
                       {isExpanded && (
                         <div className="mt-1.5 max-h-48 overflow-y-auto rounded border border-slate-700/30 bg-slate-900/40 p-2">
                           {provider.models_cache.map((model) => (
                             <div
                               key={model}
-                              className="flex items-center justify-between text-[11px] font-mono text-slate-400 py-0.5 group/model hover:bg-slate-700/30 rounded px-1 -mx-1"
+                              className="group/model -mx-1 flex items-center justify-between rounded px-1 py-0.5 text-[11px] font-mono text-slate-400 hover:bg-slate-700/30"
                             >
                               <span className="truncate">{model}</span>
                               <button
                                 onClick={() => void handleApiModelAssign(provider.id, model)}
-                                className="text-[9px] px-1.5 py-0.5 bg-blue-600/60 hover:bg-blue-500 text-blue-200 rounded opacity-0 group-hover/model:opacity-100 transition-opacity whitespace-nowrap ml-2"
+                                className="ml-2 whitespace-nowrap rounded bg-blue-600/60 px-1.5 py-0.5 text-[9px] text-blue-200 opacity-0 transition-opacity hover:bg-blue-500 group-hover/model:opacity-100"
                                 title={t({
                                   ko: "에이전트에 배정",
                                   en: "Assign to agent",
@@ -330,7 +499,7 @@ export default function ApiSettingsTab({ t, localeTag, apiState }: ApiSettingsTa
                                   zh: "分配给代理",
                                 })}
                               >
-                                {t({ ko: "배정", en: "Assign", ja: "割当", zh: "分配" })}
+                                {t({ ko: "배정", en: "Assign", ja: "割り当て", zh: "分配" })}
                               </button>
                             </div>
                           ))}

--- a/src/components/settings/ApiSettingsTab.tsx
+++ b/src/components/settings/ApiSettingsTab.tsx
@@ -108,10 +108,10 @@ export default function ApiSettingsTab({ t, localeTag, apiState }: ApiSettingsTa
               </label>
               <p className="mb-2 text-[11px] text-slate-500">
                 {t({
-                  ko: "OpenCode Go와 Alibaba Coding Plan용 공식 프리셋입니다.",
-                  en: "Official presets for OpenCode Go and Alibaba Coding Plan.",
-                  ja: "OpenCode Go と Alibaba Coding Plan 向けの公式プリセットです。",
-                  zh: "适用于 OpenCode Go 与 Alibaba Coding Plan 的官方预设。",
+                  ko: "OpenCode Go와 Bailian Coding Plan용 공식 프리셋입니다.",
+                  en: "Official presets for OpenCode Go and Bailian Coding Plan.",
+                  ja: "OpenCode Go と Bailian Coding Plan 向けの公式プリセットです。",
+                  zh: "适用于 OpenCode Go 与 Bailian Coding Plan 的官方预设。",
                 })}
               </p>
 

--- a/src/components/settings/ApiSettingsTab.tsx
+++ b/src/components/settings/ApiSettingsTab.tsx
@@ -29,6 +29,7 @@ export default function ApiSettingsTab({ t, localeTag, apiState }: ApiSettingsTa
     setApiSaveError,
     setApiModelsExpanded,
     loadApiProviders,
+    loadApiPresets,
     handleApiProviderSave,
     handleApiProviderDelete,
     handleApiProviderTest,
@@ -63,8 +64,10 @@ export default function ApiSettingsTab({ t, localeTag, apiState }: ApiSettingsTa
           </h3>
           <div className="flex items-center gap-2">
             <button
-              onClick={() => void loadApiProviders()}
-              disabled={apiProvidersLoading}
+              onClick={() => {
+                void Promise.all([loadApiProviders(), loadApiPresets()]);
+              }}
+              disabled={apiProvidersLoading || apiPresetsLoading}
               className="text-xs text-blue-400 transition-colors hover:text-blue-300 disabled:opacity-50"
             >
               {t({ ko: "새로고침", en: "Refresh", ja: "更新", zh: "刷新" })}

--- a/src/components/settings/types.ts
+++ b/src/components/settings/types.ts
@@ -1,5 +1,12 @@
 import type { Dispatch, SetStateAction } from "react";
-import type { ApiProvider, ApiProviderType, DeviceCodeStart, OAuthConnectProvider, OAuthStatus } from "../../api";
+import type {
+  ApiProvider,
+  ApiProviderOfficialPreset,
+  ApiProviderType,
+  DeviceCodeStart,
+  OAuthConnectProvider,
+  OAuthStatus,
+} from "../../api";
 import type { UiLanguage } from "../../i18n";
 import type {
   Agent,
@@ -39,6 +46,7 @@ export interface ApiFormState {
   type: ApiProviderType;
   base_url: string;
   api_key: string;
+  preset_key: string | null;
 }
 
 export type ApiTestResultMap = Record<string, { ok: boolean; msg: string }>;
@@ -95,10 +103,13 @@ export interface OAuthConnectCardProps {
 export interface ApiStateBundle {
   apiProviders: ApiProvider[];
   apiProvidersLoading: boolean;
+  apiOfficialPresets: Record<string, ApiProviderOfficialPreset>;
+  apiPresetsLoading: boolean;
   apiAddMode: boolean;
   apiEditingId: string | null;
   apiForm: ApiFormState;
   apiSaving: boolean;
+  apiSaveError: string | null;
   apiTesting: string | null;
   apiTestResult: ApiTestResultMap;
   apiModelsExpanded: Record<string, boolean>;
@@ -109,6 +120,7 @@ export interface ApiStateBundle {
   setApiAddMode: Dispatch<SetStateAction<boolean>>;
   setApiEditingId: Dispatch<SetStateAction<string | null>>;
   setApiForm: Dispatch<SetStateAction<ApiFormState>>;
+  setApiSaveError: Dispatch<SetStateAction<string | null>>;
   setApiModelsExpanded: Dispatch<SetStateAction<Record<string, boolean>>>;
   setApiAssignTarget: Dispatch<SetStateAction<ApiAssignTarget | null>>;
   loadApiProviders: () => Promise<void>;

--- a/src/components/settings/types.ts
+++ b/src/components/settings/types.ts
@@ -124,6 +124,7 @@ export interface ApiStateBundle {
   setApiModelsExpanded: Dispatch<SetStateAction<Record<string, boolean>>>;
   setApiAssignTarget: Dispatch<SetStateAction<ApiAssignTarget | null>>;
   loadApiProviders: () => Promise<void>;
+  loadApiPresets: () => Promise<void>;
   handleApiProviderSave: () => Promise<void>;
   handleApiProviderDelete: (id: string) => Promise<void>;
   handleApiProviderTest: (id: string) => Promise<void>;

--- a/src/components/settings/useApiProvidersState.test.tsx
+++ b/src/components/settings/useApiProvidersState.test.tsx
@@ -1,0 +1,90 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useApiProvidersState } from "./useApiProvidersState";
+
+const apiMocks = vi.hoisted(() => ({
+  createApiProvider: vi.fn(),
+  deleteApiProvider: vi.fn(),
+  getAgents: vi.fn(),
+  getApiProviderPresets: vi.fn(),
+  getApiProviders: vi.fn(),
+  getDepartments: vi.fn(),
+  testApiProvider: vi.fn(),
+  updateAgent: vi.fn(),
+  updateApiProvider: vi.fn(),
+}));
+
+vi.mock("../../api", () => ({
+  createApiProvider: apiMocks.createApiProvider,
+  deleteApiProvider: apiMocks.deleteApiProvider,
+  getAgents: apiMocks.getAgents,
+  getApiProviderPresets: apiMocks.getApiProviderPresets,
+  getApiProviders: apiMocks.getApiProviders,
+  getDepartments: apiMocks.getDepartments,
+  testApiProvider: apiMocks.testApiProvider,
+  updateAgent: apiMocks.updateAgent,
+  updateApiProvider: apiMocks.updateApiProvider,
+}));
+
+function t(messages: Record<string, string>): string {
+  return messages.en ?? messages.ko ?? messages.ja ?? messages.zh ?? Object.values(messages)[0] ?? "";
+}
+
+describe("useApiProvidersState preset loading", () => {
+  beforeEach(() => {
+    apiMocks.getApiProviders.mockResolvedValue([]);
+    apiMocks.getApiProviderPresets.mockRejectedValue(new Error("preset load failed"));
+    apiMocks.createApiProvider.mockResolvedValue({ ok: true, id: "provider-1" });
+    apiMocks.deleteApiProvider.mockResolvedValue({ ok: true });
+    apiMocks.getAgents.mockResolvedValue([]);
+    apiMocks.getDepartments.mockResolvedValue([]);
+    apiMocks.testApiProvider.mockResolvedValue({ ok: true, model_count: 0, models: [] });
+    apiMocks.updateAgent.mockResolvedValue({ ok: true });
+    apiMocks.updateApiProvider.mockResolvedValue({ ok: true });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("does not auto-retry failed preset loads, but allows manual retry", async () => {
+    const { result } = renderHook(() => useApiProvidersState({ tab: "api", t }));
+
+    await waitFor(() => {
+      expect(apiMocks.getApiProviderPresets).toHaveBeenCalledTimes(1);
+      expect(result.current.apiPresetsLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(apiMocks.getApiProviderPresets).toHaveBeenCalledTimes(1);
+
+    apiMocks.getApiProviderPresets.mockResolvedValueOnce({
+      presets: {},
+      official_presets: {
+        "opencode-go-openai": {
+          label: "OpenCode Go (OpenAI)",
+          description: "Preset",
+          type: "openai",
+          base_url: "https://opencode.ai/zen/go/v1",
+          docs_url: "https://opencode.ai/docs/ko/go/",
+          api_key_hint: "Use an OpenCode Go direct API key for this endpoint.",
+          api_key_placeholder: "sk-...",
+          fallback_models: ["glm-5"],
+        },
+      },
+    });
+
+    await act(async () => {
+      await result.current.loadApiPresets();
+    });
+
+    expect(apiMocks.getApiProviderPresets).toHaveBeenCalledTimes(2);
+    expect(result.current.apiOfficialPresets["opencode-go-openai"]?.label).toBe("OpenCode Go (OpenAI)");
+  });
+});

--- a/src/components/settings/useApiProvidersState.ts
+++ b/src/components/settings/useApiProvidersState.ts
@@ -9,15 +9,19 @@ const DEFAULT_API_FORM: ApiFormState = {
   type: "openai",
   base_url: "https://api.openai.com/v1",
   api_key: "",
+  preset_key: null,
 };
 
 export function useApiProvidersState({ tab, t }: { tab: SettingsTab; t: TFunction }): ApiStateBundle {
   const [apiProviders, setApiProviders] = useState<ApiProvider[]>([]);
   const [apiProvidersLoading, setApiProvidersLoading] = useState(false);
+  const [apiOfficialPresets, setApiOfficialPresets] = useState<Record<string, api.ApiProviderOfficialPreset>>({});
+  const [apiPresetsLoading, setApiPresetsLoading] = useState(false);
   const [apiAddMode, setApiAddMode] = useState(false);
   const [apiEditingId, setApiEditingId] = useState<string | null>(null);
   const [apiForm, setApiForm] = useState<ApiFormState>(DEFAULT_API_FORM);
   const [apiSaving, setApiSaving] = useState(false);
+  const [apiSaveError, setApiSaveError] = useState<string | null>(null);
   const [apiTesting, setApiTesting] = useState<string | null>(null);
   const [apiTestResult, setApiTestResult] = useState<Record<string, { ok: boolean; msg: string }>>({});
   const [apiModelsExpanded, setApiModelsExpanded] = useState<Record<string, boolean>>({});
@@ -26,14 +30,15 @@ export function useApiProvidersState({ tab, t }: { tab: SettingsTab; t: TFunctio
   const [apiAssignDepts, setApiAssignDepts] = useState<Department[]>([]);
   const [apiAssigning, setApiAssigning] = useState(false);
 
-  const apiLoadedRef = useRef(false);
+  const apiProvidersLoadedRef = useRef(false);
+  const apiPresetsLoadedRef = useRef(false);
 
   const loadApiProviders = useCallback(async () => {
     setApiProvidersLoading(true);
     try {
       const providers = await api.getApiProviders();
       setApiProviders(providers);
-      apiLoadedRef.current = true;
+      apiProvidersLoadedRef.current = true;
     } catch (error) {
       console.error("Failed to load API providers:", error);
     } finally {
@@ -41,21 +46,39 @@ export function useApiProvidersState({ tab, t }: { tab: SettingsTab; t: TFunctio
     }
   }, []);
 
+  const loadApiPresets = useCallback(async () => {
+    setApiPresetsLoading(true);
+    try {
+      const catalog = await api.getApiProviderPresets();
+      setApiOfficialPresets(catalog.official_presets ?? {});
+      apiPresetsLoadedRef.current = true;
+    } catch (error) {
+      console.error("Failed to load API provider presets:", error);
+    } finally {
+      setApiPresetsLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
-    if (tab === "api" && !apiLoadedRef.current && !apiProvidersLoading) {
+    if (tab === "api" && !apiProvidersLoadedRef.current && !apiProvidersLoading) {
       void loadApiProviders();
     }
-  }, [tab, apiProvidersLoading, loadApiProviders]);
+    if (tab === "api" && !apiPresetsLoadedRef.current && !apiPresetsLoading) {
+      void loadApiPresets();
+    }
+  }, [tab, apiProvidersLoading, apiPresetsLoading, loadApiProviders, loadApiPresets]);
 
   const handleApiProviderSave = useCallback(async () => {
     if (!apiForm.name.trim() || !apiForm.base_url.trim()) return;
     setApiSaving(true);
+    setApiSaveError(null);
     try {
       if (apiEditingId) {
         await api.updateApiProvider(apiEditingId, {
           name: apiForm.name,
           type: apiForm.type,
           base_url: apiForm.base_url,
+          preset_key: apiForm.preset_key,
           ...(apiForm.api_key ? { api_key: apiForm.api_key } : {}),
         });
       } else {
@@ -64,6 +87,7 @@ export function useApiProvidersState({ tab, t }: { tab: SettingsTab; t: TFunctio
           type: apiForm.type,
           base_url: apiForm.base_url,
           api_key: apiForm.api_key || undefined,
+          preset_key: apiForm.preset_key,
         });
       }
       setApiAddMode(false);
@@ -72,6 +96,7 @@ export function useApiProvidersState({ tab, t }: { tab: SettingsTab; t: TFunctio
       await loadApiProviders();
     } catch (error) {
       console.error("API provider save failed:", error);
+      setApiSaveError(error instanceof Error ? error.message : String(error));
     } finally {
       setApiSaving(false);
     }
@@ -130,11 +155,13 @@ export function useApiProvidersState({ tab, t }: { tab: SettingsTab; t: TFunctio
   const handleApiEditStart = useCallback((provider: ApiProvider) => {
     setApiEditingId(provider.id);
     setApiAddMode(true);
+    setApiSaveError(null);
     setApiForm({
       name: provider.name,
       type: provider.type,
       base_url: provider.base_url,
       api_key: "",
+      preset_key: provider.preset_key,
     });
   }, []);
 
@@ -183,10 +210,13 @@ export function useApiProvidersState({ tab, t }: { tab: SettingsTab; t: TFunctio
   return {
     apiProviders,
     apiProvidersLoading,
+    apiOfficialPresets,
+    apiPresetsLoading,
     apiAddMode,
     apiEditingId,
     apiForm,
     apiSaving,
+    apiSaveError,
     apiTesting,
     apiTestResult,
     apiModelsExpanded,
@@ -197,6 +227,7 @@ export function useApiProvidersState({ tab, t }: { tab: SettingsTab; t: TFunctio
     setApiAddMode,
     setApiEditingId,
     setApiForm,
+    setApiSaveError,
     setApiModelsExpanded,
     setApiAssignTarget,
     loadApiProviders,

--- a/src/components/settings/useApiProvidersState.ts
+++ b/src/components/settings/useApiProvidersState.ts
@@ -51,10 +51,12 @@ export function useApiProvidersState({ tab, t }: { tab: SettingsTab; t: TFunctio
     try {
       const catalog = await api.getApiProviderPresets();
       setApiOfficialPresets(catalog.official_presets ?? {});
-      apiPresetsLoadedRef.current = true;
     } catch (error) {
       console.error("Failed to load API provider presets:", error);
     } finally {
+      // Stop the effect from tight-loop retrying after a failed request.
+      // Users can still retry explicitly via the API tab refresh action.
+      apiPresetsLoadedRef.current = true;
       setApiPresetsLoading(false);
     }
   }, []);
@@ -231,6 +233,7 @@ export function useApiProvidersState({ tab, t }: { tab: SettingsTab; t: TFunctio
     setApiModelsExpanded,
     setApiAssignTarget,
     loadApiProviders,
+    loadApiPresets,
     handleApiProviderSave,
     handleApiProviderDelete,
     handleApiProviderTest,


### PR DESCRIPTION
## Summary

- Add an official preset layer on top of the existing `openai` and `anthropic` API provider flow.
- Expose four official presets in Settings > API for OpenCode Go and Bailian Coding Plan.
- Enforce preset-owned `type` and `base_url`, seed fallback models immediately, and merge them with live model discovery.
- Harden the preset lifecycle after review by stopping failed preset catalog retry loops and invalidating stale cached models when providers switch into or out of preset mode.
- Re-validate retained stored keys when switching into the Bailian preset so legacy non-`sk-sp-` keys cannot slip through.

## Related Issue

Closes #61

## Type of Change

- [x] New feature
- [x] Bug fix
- [x] Documentation
- [x] Tests
- [ ] CI / build / tooling
- [ ] Other

## Key Changes

- Add four official presets:
  - `OpenCode Go (OpenAI)`
  - `OpenCode Go (Anthropic)`
  - `Bailian Coding Plan (OpenAI)`
  - `Bailian Coding Plan (Anthropic)`
- Persist `preset_key` and enforce server-owned `type` and `base_url` when a preset is selected.
- Seed fallback model lists immediately and merge or dedupe them with live `/models` results.
- Add Bailian `sk-sp-` API key prefix validation, including retained-key revalidation during preset transitions.
- Stop preset catalog retry loops after failed `/api/api-providers/presets` loads; retry happens only when the user explicitly refreshes.
- Reset stale `models_cache` entries when providers switch into or out of preset mode so invalid model IDs are not assignable.
- Update Settings > API UI, README / README_ko, and API/Web/Schema coverage.

## Base Branch Policy

- External contributor PRs must target `dev`.
- `main` is only for maintainer-approved emergency hotfix PRs.
- If merged to `main` as hotfix, `main -> dev` back-merge is required.

## Checklist

- [x] Base branch is `dev`
- [x] Linked issue or context is included
- [x] Docs/README were updated if behavior or setup changed
- [x] Added focused regression tests for preset retry and cache transition behavior

## Local Validation

Initial validation from the earlier PR iteration:
- [x] `pnpm run format:check`
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] `pnpm run test:api`
- [x] `pnpm run test:web`
- [x] `pnpm run openapi:check`
- [x] `pnpm run test:ci`

Follow-up validation for the review fixes in this update:
- [x] `pnpm exec vitest run src/components/settings/ApiSettingsTab.test.tsx src/components/settings/useApiProvidersState.test.tsx`
- [x] `pnpm exec vitest run --config server/vitest.config.ts server/modules/routes/ops/api-providers.test.ts`
- [x] `pnpm exec prettier --check src/components/settings/ApiSettingsTab.tsx src/components/settings/ApiSettingsTab.test.tsx src/components/settings/useApiProvidersState.ts src/components/settings/useApiProvidersState.test.tsx src/components/settings/types.ts server/modules/routes/ops/api-providers.ts server/modules/routes/ops/api-providers.test.ts`
- [x] `pnpm exec eslint src/components/settings/ApiSettingsTab.tsx src/components/settings/useApiProvidersState.ts server/modules/routes/ops/api-providers.ts`