### PR TITLE
fix(ui): use translation function for EmojiPicker categories

### DIFF
--- a/server/modules/bootstrap/schema/oauth-runtime.test.ts
+++ b/server/modules/bootstrap/schema/oauth-runtime.test.ts
@@ -105,9 +105,11 @@ describe("initializeOAuthRuntime", () => {
       runInTransaction: (fn) => fn(),
     });
 
-    const agentSql = (db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='agents'").get() as {
-      sql: string;
-    }).sql;
+    const agentSql = (
+      db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='agents'").get() as {
+        sql: string;
+      }
+    ).sql;
     const historySql = (
       db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='skill_learning_history'").get() as {
         sql: string;
@@ -188,17 +190,19 @@ describe("initializeOAuthRuntime", () => {
       },
     });
 
-    const agentSql = (db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='agents'").get() as {
-      sql: string;
-    }).sql;
+    const agentSql = (
+      db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='agents'").get() as {
+        sql: string;
+      }
+    ).sql;
     const historySql = (
       db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='skill_learning_history'").get() as {
         sql: string;
       }
     ).sql;
-    const row = db.prepare("SELECT workflow_pack_key, cli_provider, created_at FROM agents WHERE id = ?").get(
-      "legacy-agent",
-    ) as {
+    const row = db
+      .prepare("SELECT workflow_pack_key, cli_provider, created_at FROM agents WHERE id = ?")
+      .get("legacy-agent") as {
       workflow_pack_key: string;
       cli_provider: string;
       created_at: number;

--- a/server/modules/bootstrap/schema/oauth-runtime.ts
+++ b/server/modules/bootstrap/schema/oauth-runtime.ts
@@ -125,7 +125,8 @@ export function initializeOAuthRuntime(deps: OAuthRuntimeDeps): OAuthRuntimeHelp
   }
   // 기존 DB의 provider CHECK 제약 확장 (SQLite는 ALTER CHECK 미지원이므로 테이블 재구성이 필요)
   try {
-    const agentSql = (db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='agents'").get() as any)?.sql ?? "";
+    const agentSql =
+      (db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='agents'").get() as any)?.sql ?? "";
     if (agentSql && !agentSql.includes("'kimi'")) {
       const workflowPackExpr = hasColumn("agents", "workflow_pack_key")
         ? "COALESCE(workflow_pack_key, 'development')"

--- a/server/modules/routes/collab/coordination/cross-dept-cooperation.test.ts
+++ b/server/modules/routes/collab/coordination/cross-dept-cooperation.test.ts
@@ -111,7 +111,8 @@ describe("createCrossDeptCooperationTools", () => {
       sendAgentMessage: vi.fn(),
       notifyCeo: vi.fn(),
       l: (ko: unknown, en: unknown, ja: unknown, zh: unknown) => ({ ko, en, ja, zh }),
-      pickL: (messages: Record<string, unknown>, lang: string) => pickVariant(messages[lang] ?? messages.en ?? messages.ko),
+      pickL: (messages: Record<string, unknown>, lang: string) =>
+        pickVariant(messages[lang] ?? messages.en ?? messages.ko),
       startTaskExecutionForAgent: vi.fn(),
       linkCrossDeptTaskToParentSubtask: vi.fn(() => null),
       detectProjectPath: vi.fn(() => "/workspace/demo"),
@@ -156,9 +157,9 @@ describe("createCrossDeptCooperationTools", () => {
 
     vi.runAllTimers();
 
-    const crossTask = db.prepare("SELECT status, assigned_agent_id, source_task_id FROM tasks WHERE source_task_id = ?").get(
-      "task-parent",
-    ) as
+    const crossTask = db
+      .prepare("SELECT status, assigned_agent_id, source_task_id FROM tasks WHERE source_task_id = ?")
+      .get("task-parent") as
       | {
           status: string;
           assigned_agent_id: string | null;
@@ -220,7 +221,8 @@ describe("createCrossDeptCooperationTools", () => {
       sendAgentMessage: vi.fn(),
       notifyCeo: vi.fn(),
       l: (ko: unknown, en: unknown, ja: unknown, zh: unknown) => ({ ko, en, ja, zh }),
-      pickL: (messages: Record<string, unknown>, lang: string) => pickVariant(messages[lang] ?? messages.en ?? messages.ko),
+      pickL: (messages: Record<string, unknown>, lang: string) =>
+        pickVariant(messages[lang] ?? messages.en ?? messages.ko),
       startTaskExecutionForAgent: vi.fn(),
       linkCrossDeptTaskToParentSubtask: vi.fn(() => "subtask-linked"),
       detectProjectPath: vi.fn(() => "/workspace/demo"),

--- a/src/components/agent-manager/AgentFormModal.tsx
+++ b/src/components/agent-manager/AgentFormModal.tsx
@@ -222,6 +222,7 @@ export default function AgentFormModal({
                   {tr("이모지", "Emoji")}
                 </label>
                 <EmojiPicker
+                  tr={tr}
                   value={form.avatar_emoji}
                   onChange={(emoji) => setForm({ ...form, avatar_emoji: emoji })}
                 />

--- a/src/components/agent-manager/DepartmentFormModal.tsx
+++ b/src/components/agent-manager/DepartmentFormModal.tsx
@@ -237,7 +237,7 @@ export default function DepartmentFormModal({
               <label className="block text-xs mb-1.5 font-medium" style={{ color: "var(--th-text-secondary)" }}>
                 {tr("아이콘", "Icon")}
               </label>
-              <EmojiPicker value={form.icon} onChange={(emoji) => setForm({ ...form, icon: emoji })} />
+              <EmojiPicker tr={tr} value={form.icon} onChange={(emoji) => setForm({ ...form, icon: emoji })} />
             </div>
             <div className="flex-1">
               <label className="block text-xs mb-1.5 font-medium" style={{ color: "var(--th-text-secondary)" }}>

--- a/src/components/agent-manager/EmojiPicker.tsx
+++ b/src/components/agent-manager/EmojiPicker.tsx
@@ -21,10 +21,12 @@ export function StackedSpriteIcon({ sprites }: { sprites: [number, number] }) {
 }
 
 export default function EmojiPicker({
+  tr,
   value,
   onChange,
   size = "md",
 }: {
+  tr: (ko: string, en: string) => string;
   value: string;
   onChange: (emoji: string) => void;
   size?: "sm" | "md";
@@ -63,12 +65,12 @@ export default function EmojiPicker({
           }}
         >
           {EMOJI_GROUPS.map((group) => (
-            <div key={group.label} className="mb-2 last:mb-0">
+            <div key={group.labelEn} className="mb-2 last:mb-0">
               <div
                 className="text-[10px] font-semibold uppercase tracking-widest mb-1"
                 style={{ color: "var(--th-text-muted)" }}
               >
-                {group.label}
+                {tr(group.label, group.labelEn)}
               </div>
               <div className="grid grid-cols-8 gap-0.5">
                 {group.emojis.map((emoji) => (

--- a/src/components/agent-manager/constants.ts
+++ b/src/components/agent-manager/constants.ts
@@ -2,7 +2,16 @@ import type { AgentRole, CliProvider } from "../../types";
 import type { DeptForm, FormData } from "./types";
 
 export const ROLES: AgentRole[] = ["team_leader", "senior", "junior", "intern"];
-export const CLI_PROVIDERS: CliProvider[] = ["claude", "codex", "gemini", "opencode", "kimi", "copilot", "antigravity", "api"];
+export const CLI_PROVIDERS: CliProvider[] = [
+  "claude",
+  "codex",
+  "gemini",
+  "opencode",
+  "kimi",
+  "copilot",
+  "antigravity",
+  "api",
+];
 
 export const ROLE_LABEL: Record<string, { ko: string; en: string }> = {
   team_leader: { ko: "팀장", en: "Leader" },

--- a/src/components/settings/useApiProvidersState.ts
+++ b/src/components/settings/useApiProvidersState.ts
@@ -174,9 +174,7 @@ export function useApiProvidersState({ tab, t }: { tab: SettingsTab; t: TFunctio
         api.getAgents(),
         api.getDepartments({ workflowPackKey: "development" }),
       ]);
-      setApiAssignAgents(
-        agents.filter((agent) => (agent.workflow_pack_key ?? "development") === "development"),
-      );
+      setApiAssignAgents(agents.filter((agent) => (agent.workflow_pack_key ?? "development") === "development"));
       setApiAssignDepts(depts);
     } catch (error) {
       console.error("Failed to load agents:", error);


### PR DESCRIPTION
## Summary
- Added `tr` prop to `EmojiPicker` component
- Replaced hardcoded Korean labels with translatable strings
- Updated AgentFormModal and DepartmentFormModal to pass `tr` prop

<!-- What does this PR do? Keep it brief (1-3 sentences). -->

## Related Issue
- Fixes #65 
<!-- Link the issue this PR addresses. Use "Closes #123" to auto-close on merge. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Other (describe below)

## Base Branch Policy

- External contributor PRs must target `dev`.
- `main` is only for maintainer-approved emergency hotfix PRs.
- If merged to `main` as hotfix, `main -> dev` back-merge is required.

## Checklist

- [x] Base branch is `dev` (or emergency hotfix to `main` with rationale below)
- [x] Linked issue or context is included
- [x] `pnpm run format:check` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run build` passes
- [ ] `pnpm run test:ci` passes (or reason provided if skipped) `error from branch dev.`
- [ ] Docs/README were updated if behavior or setup changed

## Hotfix Rationale (required only when base is `main`)

<!-- Explain why this must go directly to main and who approved it. -->
