### PR TITLE
feat(providers): add Novita AI as a new LLM provider

### DIFF
--- a/server/modules/bootstrap/schema/api-providers-schema.test.ts
+++ b/server/modules/bootstrap/schema/api-providers-schema.test.ts
@@ -118,6 +118,7 @@ describe("api_providers schema migrations", () => {
           | undefined
       )?.sql;
       expect(tableSql).toContain("'cerebras'");
+      expect(tableSql).toContain("'novita'");
     } finally {
       db.close();
     }

--- a/server/modules/bootstrap/schema/base-schema.ts
+++ b/server/modules/bootstrap/schema/base-schema.ts
@@ -365,7 +365,7 @@ CREATE INDEX IF NOT EXISTS idx_skill_learning_history_skill_lookup
 CREATE TABLE IF NOT EXISTS api_providers (
   id TEXT PRIMARY KEY,
   name TEXT NOT NULL,
-  type TEXT NOT NULL DEFAULT 'openai' CHECK(type IN ('openai','anthropic','google','ollama','openrouter','together','groq','cerebras','custom')),
+  type TEXT NOT NULL DEFAULT 'openai' CHECK(type IN ('openai','anthropic','google','ollama','openrouter','together','groq','cerebras','novita','custom')),
   base_url TEXT NOT NULL,
   api_key_enc TEXT,
   preset_key TEXT,

--- a/server/modules/routes/ops/api-providers.test.ts
+++ b/server/modules/routes/ops/api-providers.test.ts
@@ -358,6 +358,58 @@ describe("api provider routes", () => {
     }
   });
 
+  it("returns novita-ai in the official presets catalog with correct metadata", async () => {
+    const { app, db } = await createHarness();
+
+    try {
+      const response = await request(app).get("/api/api-providers/presets").expect(200);
+
+      expect(response.body.ok).toBe(true);
+      expect(response.body.presets.novita.base_url).toBe("https://api.novita.ai/openai");
+      expect(response.body.official_presets["novita-ai"]).toMatchObject({
+        type: "novita",
+        base_url: "https://api.novita.ai/openai",
+      });
+      expect(response.body.official_presets["novita-ai"].fallback_models).toContain("moonshotai/kimi-k2.5");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("creates a novita-ai preset-backed provider with seeded fallback models", async () => {
+    const { app, db } = await createHarness();
+
+    try {
+      const createResponse = await request(app).post("/api/api-providers").send({
+        name: "Novita AI",
+        preset_key: "novita-ai",
+        api_key: "test-novita-key",
+      });
+
+      expect(createResponse.status).toBe(200);
+      expect(createResponse.body.ok).toBe(true);
+
+      const row = db
+        .prepare("SELECT name, type, base_url, preset_key, models_cache FROM api_providers WHERE id = ?")
+        .get(createResponse.body.id) as
+        | { name: string; type: string; base_url: string; preset_key: string | null; models_cache: string | null }
+        | undefined;
+
+      expect(row).toMatchObject({
+        name: "Novita AI",
+        type: "novita",
+        base_url: "https://api.novita.ai/openai",
+        preset_key: "novita-ai",
+      });
+      const models = JSON.parse(String(row?.models_cache));
+      expect(models).toContain("moonshotai/kimi-k2.5");
+      expect(models).toContain("deepseek/deepseek-v3.2");
+      expect(models).toContain("zai-org/glm-5");
+    } finally {
+      db.close();
+    }
+  });
+
   it("merges fetched models with preset fallback models during test", async () => {
     const { app, db } = await createHarness();
 

--- a/server/modules/routes/ops/api-providers.ts
+++ b/server/modules/routes/ops/api-providers.ts
@@ -18,9 +18,10 @@ type ApiProviderType =
   | "together"
   | "groq"
   | "cerebras"
+  | "novita"
   | "custom";
 
-type OfficialApiProviderType = Extract<ApiProviderType, "openai" | "anthropic">;
+type OfficialApiProviderType = Extract<ApiProviderType, "openai" | "anthropic" | "novita">;
 
 type OfficialApiProviderPreset = {
   label: string;
@@ -76,6 +77,7 @@ const API_PROVIDER_PRESETS: Record<ApiProviderType, ApiProviderPreset> = {
   together: { base_url: "https://api.together.xyz/v1", models_path: "/models", auth_header: "Bearer" },
   groq: { base_url: "https://api.groq.com/openai/v1", models_path: "/models", auth_header: "Bearer" },
   cerebras: { base_url: "https://api.cerebras.ai/v1", models_path: "/models", auth_header: "Bearer" },
+  novita: { base_url: "https://api.novita.ai/openai", models_path: "/models", auth_header: "Bearer" },
   custom: { base_url: "", models_path: "/models", auth_header: "Bearer" },
 };
 
@@ -139,6 +141,16 @@ const OFFICIAL_API_PROVIDER_PRESETS = {
       "glm-4.7",
     ],
     required_api_key_prefix: "sk-sp-",
+  },
+  "novita-ai": {
+    label: "Novita AI",
+    description: "Novita AI direct API preset using the OpenAI-compatible protocol.",
+    type: "novita",
+    base_url: "https://api.novita.ai/openai",
+    docs_url: "https://novita.ai/docs",
+    api_key_hint: "Use a Novita AI API key for this endpoint.",
+    api_key_placeholder: "...",
+    fallback_models: ["moonshotai/kimi-k2.5", "deepseek/deepseek-v3.2", "zai-org/glm-5"],
   },
 } as const satisfies Record<string, OfficialApiProviderPreset>;
 

--- a/server/modules/workflow/agents/providers/types.ts
+++ b/server/modules/workflow/agents/providers/types.ts
@@ -25,6 +25,7 @@ export type ApiProviderType =
   | "together"
   | "groq"
   | "cerebras"
+  | "novita"
   | "custom";
 
 export interface ApiProviderRow {

--- a/src/api/providers-reports-github.ts
+++ b/src/api/providers-reports-github.ts
@@ -10,6 +10,7 @@ export type ApiProviderType =
   | "together"
   | "groq"
   | "cerebras"
+  | "novita"
   | "custom";
 
 export interface ApiProvider {


### PR DESCRIPTION
## Summary

- Adds `novita` as a new `ApiProviderType` across server types, route handler, and frontend API client
- Registers a generic preset for `novita` (endpoint: `https://api.novita.ai/openai`, OpenAI-compatible Bearer auth)
- Adds an official preset `novita-ai` with seeded fallback models: `moonshotai/kimi-k2.5`, `deepseek/deepseek-v3.2`, `zai-org/glm-5`
- Updates the SQLite schema `CHECK` constraint to accept `type='novita'`
- Adds vitest coverage for the presets catalog and preset-backed provider creation

## Files changed

| File | Change |
|------|--------|
| `server/modules/workflow/agents/providers/types.ts` | Add `"novita"` to `ApiProviderType` |
| `src/api/providers-reports-github.ts` | Add `"novita"` to frontend `ApiProviderType` |
| `server/modules/routes/ops/api-providers.ts` | Add `novita` type, preset entry, and `novita-ai` official preset |
| `server/modules/bootstrap/schema/base-schema.ts` | Update `CHECK` constraint |
| `server/modules/routes/ops/api-providers.test.ts` | Two new tests for Novita |
| `server/modules/bootstrap/schema/api-providers-schema.test.ts` | Assert `'novita'` present after schema migration |

🤖 Generated with [Claude Code](https://claude.com/claude-code)