### PR TITLE
Safely release completed Hermes task worktrees

### DIFF
--- a/server/modules/bootstrap/schema/seeds.hermes-member.test.ts
+++ b/server/modules/bootstrap/schema/seeds.hermes-member.test.ts
@@ -32,4 +32,55 @@ describe("default agent seed lifecycle", () => {
       db.close();
     }
   });
+
+  it("preserves the Notion-managed department order across restarts", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      applyBaseSchema(db);
+      applyDefaultSeeds(db);
+      db.exec("DELETE FROM agents");
+      db.prepare(`
+        INSERT INTO agents (id, name, department_id, role, personality)
+        VALUES ('linked-athena', 'Athena', 'dev', 'team_leader', ?)
+      `).run(`hermes-member:${"1".repeat(64)}`);
+
+      db.exec("DROP INDEX IF EXISTS idx_departments_sort_order");
+      db.prepare("UPDATE departments SET sort_order = 106 WHERE id = 'dev'").run();
+      const insert = db.prepare(`
+        INSERT INTO departments (id, name, name_ko, name_ja, name_zh, icon, color, sort_order)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      for (const [id, name, icon, color, sortOrder] of [
+        ["representative", "代表", "👤", "#ef4444", 101],
+        ["secretariat", "秘書室", "🧑‍💼", "#8b5cf6", 102],
+        ["marketing", "マーケティング部門", "📊", "#f59e0b", 103],
+        ["social", "SNS運用部門", "🌏", "#92400e", 104],
+        ["sales", "営業部門", "💸", "#10b981", 105],
+        ["backoffice", "バックオフィス部門", "⚙️", "#6b7280", 107],
+      ] as const) {
+        insert.run(id, name, name, name, name, icon, color, sortOrder);
+      }
+      db.exec("CREATE UNIQUE INDEX idx_departments_sort_order ON departments(sort_order)");
+
+      applyDefaultSeeds(db);
+
+      const rows = db.prepare(`
+        SELECT id, sort_order
+        FROM departments
+        WHERE id IN ('representative', 'secretariat', 'marketing', 'social', 'sales', 'dev', 'backoffice')
+        ORDER BY sort_order
+      `).all();
+      expect(rows).toEqual([
+        { id: "representative", sort_order: 101 },
+        { id: "secretariat", sort_order: 102 },
+        { id: "marketing", sort_order: 103 },
+        { id: "social", sort_order: 104 },
+        { id: "sales", sort_order: 105 },
+        { id: "dev", sort_order: 106 },
+        { id: "backoffice", sort_order: 107 },
+      ]);
+    } finally {
+      db.close();
+    }
+  });
 });

--- a/server/modules/bootstrap/schema/seeds.hermes-member.test.ts
+++ b/server/modules/bootstrap/schema/seeds.hermes-member.test.ts
@@ -1,0 +1,35 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+
+import { applyBaseSchema } from "./base-schema.ts";
+import { applyDefaultSeeds } from "./seeds.ts";
+
+describe("default agent seed lifecycle", () => {
+  it("does not recreate deleted default agents after a Notion-linked roster is installed", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      applyBaseSchema(db);
+      applyDefaultSeeds(db);
+      db.exec("DELETE FROM agents");
+
+      const insert = db.prepare(`
+        INSERT INTO agents (id, name, department_id, role, personality)
+        VALUES (?, ?, 'dev', 'senior', ?)
+      `);
+      for (const [index, name] of ["Apollo", "Argus", "Athena", "Daedalus", "Iris", "Metis"].entries()) {
+        insert.run(`linked-${index}`, name, `hermes-member:${String(index).padStart(64, "0")}`);
+      }
+
+      applyDefaultSeeds(db);
+
+      const rows = db.prepare("SELECT name, personality FROM agents ORDER BY name").all() as Array<{
+        name: string;
+        personality: string;
+      }>;
+      expect(rows.map((row) => row.name)).toEqual(["Apollo", "Argus", "Athena", "Daedalus", "Iris", "Metis"]);
+      expect(rows.every((row) => row.personality.startsWith("hermes-member:"))).toBe(true);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/server/modules/bootstrap/schema/seeds.ts
+++ b/server/modules/bootstrap/schema/seeds.ts
@@ -248,18 +248,23 @@ export function applyDefaultSeeds(db: DbLike): void {
       ["Pipe", "파이프", "devsecops", "senior", "codex", "🔧", "CI/CD 파이프라인 전문가"],
     ];
 
+    const hasHermesLinkedRoster = Boolean(
+      db.prepare("SELECT 1 FROM agents WHERE personality LIKE 'hermes-member:%' LIMIT 1").get(),
+    );
     let added = 0;
-    for (const [name, nameKo, dept, role, provider, emoji, personality] of newAgents) {
-      if (!existingNames.has(name)) {
-        if (!existingDeptIds.has(dept)) {
-          console.warn(`[Claw-Empire] Skip adding agent "${name}": missing department "${dept}"`);
-          continue;
-        }
-        try {
-          insertAgentIfMissing.run(randomUUID(), name, nameKo, dept, role, provider, emoji, personality);
-          added++;
-        } catch (err) {
-          console.warn(`[Claw-Empire] Skip adding agent "${name}":`, err);
+    if (!hasHermesLinkedRoster) {
+      for (const [name, nameKo, dept, role, provider, emoji, personality] of newAgents) {
+        if (!existingNames.has(name)) {
+          if (!existingDeptIds.has(dept)) {
+            console.warn(`[Claw-Empire] Skip adding agent "${name}": missing department "${dept}"`);
+            continue;
+          }
+          try {
+            insertAgentIfMissing.run(randomUUID(), name, nameKo, dept, role, provider, emoji, personality);
+            added++;
+          } catch (err) {
+            console.warn(`[Claw-Empire] Skip adding agent "${name}":`, err);
+          }
         }
       }
     }

--- a/server/modules/bootstrap/schema/seeds.ts
+++ b/server/modules/bootstrap/schema/seeds.ts
@@ -189,37 +189,53 @@ export function applyDefaultSeeds(db: DbLike): void {
     } catch {
       /* noop */
     }
+    const hasNotionManagedDevelopmentRoster = Boolean(
+      db
+        .prepare(
+          "SELECT 1 FROM agents WHERE workflow_pack_key = 'development' AND personality LIKE 'hermes-member:%' LIMIT 1",
+        )
+        .get(),
+    );
+    const hasHermesLinkedRoster = Boolean(
+      db.prepare("SELECT 1 FROM agents WHERE personality LIKE 'hermes-member:%' LIMIT 1").get(),
+    );
     const DEPT_ORDER: Record<string, number> = { planning: 1, dev: 2, design: 3, qa: 4, devsecops: 5, operations: 6 };
 
     const insertDeptIfMissing = db.prepare(
       "INSERT OR IGNORE INTO departments (id, name, name_ko, icon, color, sort_order) VALUES (?, ?, ?, ?, ?, ?)",
     );
-    insertDeptIfMissing.run("qa", "QA/QC", "품질관리팀", "🔍", "#ef4444", 4);
-    insertDeptIfMissing.run("devsecops", "DevSecOps", "인프라보안팀", "🛡️", "#f97316", 5);
-
     const updateOrder = db.prepare("UPDATE departments SET sort_order = ? WHERE id = ?");
-    for (const [id, order] of Object.entries(DEPT_ORDER)) {
-      updateOrder.run(order, id);
+    if (!hasNotionManagedDevelopmentRoster) {
+      insertDeptIfMissing.run("qa", "QA/QC", "품질관리팀", "🔍", "#ef4444", 4);
+      insertDeptIfMissing.run("devsecops", "DevSecOps", "인프라보안팀", "🛡️", "#f97316", 5);
+
+      for (const [id, order] of Object.entries(DEPT_ORDER)) {
+        updateOrder.run(order, id);
+      }
+
+      const allDepartments = db
+        .prepare("SELECT id, sort_order FROM departments ORDER BY sort_order ASC, id ASC")
+        .all() as Array<{ id: string; sort_order: number }>;
+      const existingDeptIds = new Set(allDepartments.map((row) => row.id));
+      const usedOrders = new Set<number>();
+      for (const [id, order] of Object.entries(DEPT_ORDER)) {
+        if (!existingDeptIds.has(id)) continue;
+        usedOrders.add(order);
+      }
+
+      let nextOrder = 1;
+      for (const row of allDepartments) {
+        if (Object.prototype.hasOwnProperty.call(DEPT_ORDER, row.id)) continue;
+        while (usedOrders.has(nextOrder)) nextOrder += 1;
+        updateOrder.run(nextOrder, row.id);
+        usedOrders.add(nextOrder);
+        nextOrder += 1;
+      }
     }
 
-    const allDepartments = db
-      .prepare("SELECT id, sort_order FROM departments ORDER BY sort_order ASC, id ASC")
-      .all() as Array<{ id: string; sort_order: number }>;
-    const existingDeptIds = new Set(allDepartments.map((row) => row.id));
-    const usedOrders = new Set<number>();
-    for (const [id, order] of Object.entries(DEPT_ORDER)) {
-      if (!existingDeptIds.has(id)) continue;
-      usedOrders.add(order);
-    }
-
-    let nextOrder = 1;
-    for (const row of allDepartments) {
-      if (Object.prototype.hasOwnProperty.call(DEPT_ORDER, row.id)) continue;
-      while (usedOrders.has(nextOrder)) nextOrder += 1;
-      updateOrder.run(nextOrder, row.id);
-      usedOrders.add(nextOrder);
-      nextOrder += 1;
-    }
+    const existingDeptIds = new Set(
+      (db.prepare("SELECT id FROM departments").all() as Array<{ id: string }>).map((row) => row.id),
+    );
 
     try {
       db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_departments_sort_order ON departments(sort_order)");
@@ -248,9 +264,6 @@ export function applyDefaultSeeds(db: DbLike): void {
       ["Pipe", "파이프", "devsecops", "senior", "codex", "🔧", "CI/CD 파이프라인 전문가"],
     ];
 
-    const hasHermesLinkedRoster = Boolean(
-      db.prepare("SELECT 1 FROM agents WHERE personality LIKE 'hermes-member:%' LIMIT 1").get(),
-    );
     let added = 0;
     if (!hasHermesLinkedRoster) {
       for (const [name, nameKo, dept, role, provider, emoji, personality] of newAgents) {

--- a/server/modules/routes/core/agents/crud.seed-filter.test.ts
+++ b/server/modules/routes/core/agents/crud.seed-filter.test.ts
@@ -66,6 +66,47 @@ function createHarness(): { db: DatabaseSync; routes: Map<string, RouteHandler> 
       stats_xp INTEGER NOT NULL DEFAULT 0,
       created_at INTEGER NOT NULL DEFAULT 0
     );
+
+    CREATE TABLE tasks (
+      id TEXT PRIMARY KEY,
+      assigned_agent_id TEXT
+    );
+
+    CREATE TABLE subtasks (
+      id TEXT PRIMARY KEY,
+      assigned_agent_id TEXT
+    );
+
+    CREATE TABLE meeting_minute_entries (
+      id INTEGER PRIMARY KEY,
+      speaker_agent_id TEXT,
+      speaker_name TEXT NOT NULL,
+      content TEXT NOT NULL
+    );
+
+    CREATE TABLE task_report_archives (
+      id TEXT PRIMARY KEY,
+      generated_by_agent_id TEXT
+    );
+
+    CREATE TABLE project_review_decision_states (
+      id TEXT PRIMARY KEY,
+      planner_agent_id TEXT
+    );
+
+    CREATE TABLE review_round_decision_states (
+      meeting_id TEXT PRIMARY KEY,
+      snapshot_hash TEXT NOT NULL,
+      status TEXT NOT NULL,
+      planner_summary TEXT,
+      planner_agent_id TEXT,
+      planner_agent_name TEXT
+    );
+
+    CREATE TABLE project_agents (
+      project_id TEXT NOT NULL,
+      agent_id TEXT NOT NULL
+    );
   `);
 
   const routes = new Map<string, RouteHandler>();
@@ -150,6 +191,54 @@ describe("agent CRUD seed filter", () => {
       expect(res.statusCode).toBe(200);
       const payload = res.payload as { agents: Array<{ id: string }> };
       expect(payload.agents.map((agent) => agent.id)).toEqual(["dev-leader", "video_preprod-seed-2"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("DELETE /api/agents/:id preserves denormalized meeting and review attribution", () => {
+    const { db, routes } = createHarness();
+    try {
+      db.prepare(
+        "INSERT INTO agents (id, name, role, status, created_at) VALUES (?, ?, 'senior', 'idle', 1)",
+      ).run("historical-agent", "Historical Agent");
+      db.prepare(
+        "INSERT INTO meeting_minute_entries (id, speaker_agent_id, speaker_name, content) VALUES (1, ?, ?, ?)",
+      ).run("historical-agent", "Historical Agent", "Retained meeting content");
+      db.prepare(
+        `INSERT INTO review_round_decision_states
+          (meeting_id, snapshot_hash, status, planner_summary, planner_agent_id, planner_agent_name)
+         VALUES ('meeting-1', 'snapshot-1', 'ready', 'Retained planner summary', ?, ?)`,
+      ).run("historical-agent", "Historical Agent");
+
+      const handler = routes.get("DELETE /api/agents/:id");
+      expect(handler).toBeTypeOf("function");
+      const res = createFakeResponse();
+      handler?.({ params: { id: "historical-agent" } }, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(db.prepare("SELECT id FROM agents WHERE id = ?").get("historical-agent")).toBeUndefined();
+      expect(
+        db.prepare(
+          "SELECT speaker_agent_id, speaker_name, content FROM meeting_minute_entries WHERE id = 1",
+        ).get(),
+      ).toEqual({
+        speaker_agent_id: null,
+        speaker_name: "Historical Agent",
+        content: "Retained meeting content",
+      });
+      expect(
+        db.prepare(
+          `SELECT snapshot_hash, status, planner_summary, planner_agent_id, planner_agent_name
+           FROM review_round_decision_states WHERE meeting_id = 'meeting-1'`,
+        ).get(),
+      ).toEqual({
+        snapshot_hash: "snapshot-1",
+        status: "ready",
+        planner_summary: "Retained planner summary",
+        planner_agent_id: null,
+        planner_agent_name: "Historical Agent",
+      });
     } finally {
       db.close();
     }

--- a/server/modules/routes/core/departments.notion-scope.test.ts
+++ b/server/modules/routes/core/departments.notion-scope.test.ts
@@ -46,12 +46,22 @@ function harness() {
 }
 
 describe("department Notion scope", () => {
-  it("GET /api/departments exposes exactly the two Notion-managed departments", () => {
+  it("GET /api/departments exposes the complete Notion-managed department catalog", () => {
     const { db, routes } = harness();
     try {
-      for (const [id, order] of [["planning", 1], ["dev", 2], ["secretariat", 3], ["qa", 4]] as const) {
-        db.prepare("INSERT INTO departments (id, name, name_ja, sort_order) VALUES (?, ?, ?, ?)")
-          .run(id, id, id === "dev" ? "🎨 開発部門" : id === "secretariat" ? "🧑‍💼 秘書室" : id, order);
+      for (const [id, name, icon, order] of [
+        ["planning", "Planning", "📋", 1],
+        ["representative", "代表", "👤", 101],
+        ["secretariat", "秘書室", "🧑‍💼", 102],
+        ["marketing", "マーケティング部門", "📊", 103],
+        ["social", "SNS運用部門", "🌏", 104],
+        ["sales", "営業部門", "💸", 105],
+        ["dev", "開発部門", "🎨", 106],
+        ["backoffice", "バックオフィス部門", "⚙️", 107],
+        ["qa", "QA", "🔍", 4],
+      ] as const) {
+        db.prepare("INSERT INTO departments (id, name, name_ja, icon, sort_order) VALUES (?, ?, ?, ?, ?)")
+          .run(id, name, name, icon, order);
       }
       const marker = (hex: string) => `hermes-member:${hex.repeat(64)}\n\nprofile`;
       db.prepare("INSERT INTO agents VALUES (?, ?, ?, ?, ?, ?, ?)").run("athena", "アテナ", "dev", "development", marker("a"), "team_leader", "idle");
@@ -60,7 +70,15 @@ describe("department Notion scope", () => {
 
       const res = response();
       routes.get("GET /api/departments")?.({ query: { workflow_pack_key: "development" } }, res);
-      expect((res.payload as { departments: Array<{ id: string }> }).departments.map(({ id }) => id)).toEqual(["dev", "secretariat"]);
+      expect((res.payload as { departments: Array<{ id: string; name_ja: string; icon: string }> }).departments.map(({ id, name_ja, icon }) => [id, name_ja, icon])).toEqual([
+        ["representative", "代表", "👤"],
+        ["secretariat", "秘書室", "🧑‍💼"],
+        ["marketing", "マーケティング部門", "📊"],
+        ["social", "SNS運用部門", "🌏"],
+        ["sales", "営業部門", "💸"],
+        ["dev", "開発部門", "🎨"],
+        ["backoffice", "バックオフィス部門", "⚙️"],
+      ]);
     } finally {
       db.close();
     }

--- a/server/modules/routes/core/departments.notion-scope.test.ts
+++ b/server/modules/routes/core/departments.notion-scope.test.ts
@@ -1,0 +1,68 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+
+import { registerDepartmentRoutes } from "./departments.ts";
+
+type RouteHandler = (req: any, res: any) => any;
+
+function response() {
+  return {
+    statusCode: 200,
+    payload: null as unknown,
+    status(code: number) { this.statusCode = code; return this; },
+    json(payload: unknown) { this.payload = payload; return this; },
+  };
+}
+
+function harness() {
+  const db = new DatabaseSync(":memory:");
+  db.exec(`
+    CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    CREATE TABLE departments (
+      id TEXT PRIMARY KEY, name TEXT, name_ko TEXT, name_ja TEXT, name_zh TEXT,
+      icon TEXT, color TEXT, description TEXT, prompt TEXT,
+      sort_order INTEGER, created_at INTEGER
+    );
+    CREATE TABLE agents (
+      id TEXT PRIMARY KEY, name TEXT, department_id TEXT, workflow_pack_key TEXT,
+      personality TEXT, role TEXT, status TEXT
+    );
+  `);
+  const routes = new Map<string, RouteHandler>();
+  const app = {
+    get(path: string, handler: RouteHandler) { routes.set(`GET ${path}`, handler); return this; },
+    post(path: string, handler: RouteHandler) { routes.set(`POST ${path}`, handler); return this; },
+    patch(path: string, handler: RouteHandler) { routes.set(`PATCH ${path}`, handler); return this; },
+    delete(path: string, handler: RouteHandler) { routes.set(`DELETE ${path}`, handler); return this; },
+  };
+  registerDepartmentRoutes({
+    app: app as any,
+    db: db as any,
+    broadcast: () => {},
+    normalizeTextField: (value: unknown) => typeof value === "string" ? value.trim() || null : null,
+    runInTransaction: (fn: () => void) => fn(),
+  });
+  return { db, routes };
+}
+
+describe("department Notion scope", () => {
+  it("GET /api/departments exposes exactly the two Notion-managed departments", () => {
+    const { db, routes } = harness();
+    try {
+      for (const [id, order] of [["planning", 1], ["dev", 2], ["secretariat", 3], ["qa", 4]] as const) {
+        db.prepare("INSERT INTO departments (id, name, name_ja, sort_order) VALUES (?, ?, ?, ?)")
+          .run(id, id, id === "dev" ? "🎨 開発部門" : id === "secretariat" ? "🧑‍💼 秘書室" : id, order);
+      }
+      const marker = (hex: string) => `hermes-member:${hex.repeat(64)}\n\nprofile`;
+      db.prepare("INSERT INTO agents VALUES (?, ?, ?, ?, ?, ?, ?)").run("athena", "アテナ", "dev", "development", marker("a"), "team_leader", "idle");
+      db.prepare("INSERT INTO agents VALUES (?, ?, ?, ?, ?, ?, ?)").run("hermes", "エルメス", "secretariat", "development", marker("b"), "team_leader", "idle");
+      db.prepare("INSERT INTO agents VALUES (?, ?, ?, ?, ?, ?, ?)").run("default", "Default", "planning", "development", "default", "senior", "idle");
+
+      const res = response();
+      routes.get("GET /api/departments")?.({ query: { workflow_pack_key: "development" } }, res);
+      expect((res.payload as { departments: Array<{ id: string }> }).departments.map(({ id }) => id)).toEqual(["dev", "secretariat"]);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/server/modules/routes/core/departments.ts
+++ b/server/modules/routes/core/departments.ts
@@ -5,6 +5,7 @@ import {
   parseWorkflowPackKeyInput,
   readActiveOfficeWorkflowPackKey,
 } from "../../workflow/packs/department-scope.ts";
+import { readNotionManagedDevelopmentDepartmentIds } from "../../workflow/packs/notion-managed-development.ts";
 
 export type DepartmentRouteDeps = Pick<
   RuntimeContext,
@@ -58,6 +59,10 @@ export function registerDepartmentRoutes(deps: DepartmentRouteDeps): void {
   function listDevelopmentDepartments(includeSeed: boolean): unknown[] {
     const seedFilterClause = includeSeed ? "" : " AND a.id NOT LIKE '%-seed-%'";
     const agentPackExpr = hasAgentWorkflowPackColumn ? "COALESCE(a.workflow_pack_key, 'development')" : "'development'";
+    const managedDepartmentIds = readNotionManagedDevelopmentDepartmentIds(db as any);
+    const managedDepartmentClause = managedDepartmentIds
+      ? `WHERE d.id IN (${managedDepartmentIds.map(() => "?").join(", ")})`
+      : "";
     return db
       .prepare(
         `
@@ -67,10 +72,11 @@ export function registerDepartmentRoutes(deps: DepartmentRouteDeps): void {
        WHERE a.department_id = d.id
          AND ${agentPackExpr} = 'development'${seedFilterClause}) AS agent_count
     FROM departments d
+    ${managedDepartmentClause}
     ORDER BY d.sort_order ASC
   `,
       )
-      .all();
+      .all(...(managedDepartmentIds ?? []));
   }
 
   function listScopedDepartments(packKey: WorkflowPackKey, includeSeed: boolean): unknown[] {

--- a/server/modules/routes/ops/settings-stats.seed-init.test.ts
+++ b/server/modules/routes/ops/settings-stats.seed-init.test.ts
@@ -61,6 +61,7 @@ function setupDb(): DatabaseSync {
       cli_provider TEXT,
       avatar_emoji TEXT NOT NULL DEFAULT '🤖',
       personality TEXT,
+      workflow_pack_key TEXT NOT NULL DEFAULT 'development',
       status TEXT NOT NULL DEFAULT 'idle',
       current_task_id TEXT,
       stats_tasks_done INTEGER NOT NULL DEFAULT 0,
@@ -78,6 +79,7 @@ function setupDb(): DatabaseSync {
       title TEXT,
       updated_at INTEGER,
       assigned_agent_id TEXT
+      ,workflow_pack_key TEXT NOT NULL DEFAULT 'development'
     );
 
     CREATE TABLE task_logs (
@@ -113,6 +115,44 @@ function createHarness(db: DatabaseSync) {
 }
 
 describe("ops settings seed init guard", () => {
+  it("GET /api/stats reports exactly the seven Notion-managed agents and their two departments", () => {
+    const db = setupDb();
+    try {
+      for (const [id, order] of [["planning", 1], ["dev", 2], ["secretariat", 3], ["qa", 4]] as const) {
+        db.prepare("INSERT INTO departments (id, name, name_ja, sort_order) VALUES (?, ?, ?, ?)")
+          .run(id, id, id === "dev" ? "🎨 開発部門" : id === "secretariat" ? "🧑‍💼 秘書室" : id, order);
+      }
+      const marker = (hex: string) => `hermes-member:${hex.repeat(64)}\n\nprofile`;
+      for (const [index, name] of ["アポロン", "アイリス", "メティス", "ダイダロス", "アルゴス", "アテナ"].entries()) {
+        db.prepare(
+          "INSERT INTO agents (id, name, department_id, workflow_pack_key, personality, status, stats_xp) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ).run(`dev-${index + 1}`, name, "dev", "development", marker(String(index + 1)), index === 5 ? "working" : "idle", index + 1);
+      }
+      db.prepare(
+        "INSERT INTO agents (id, name, department_id, workflow_pack_key, personality, status, stats_xp) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ).run("hermes", "エルメス", "secretariat", "development", marker("a"), "idle", 7);
+      db.prepare(
+        "INSERT INTO agents (id, name, department_id, workflow_pack_key, personality, status, stats_xp) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ).run("default", "Default", "planning", "development", "default", "working", 999);
+
+      const { getRoutes } = createHarness(db);
+      const res = createFakeResponse();
+      getRoutes.get("/api/stats")?.({}, res);
+      const stats = (res.payload as {
+        stats: {
+          agents: { total: number; working: number; idle: number };
+          top_agents: Array<{ id: string }>;
+          tasks_by_department: Array<{ id: string }>;
+        };
+      }).stats;
+      expect(stats.agents).toEqual({ total: 7, working: 1, idle: 6 });
+      expect(stats.top_agents.map(({ id }) => id)).toEqual(["hermes", "dev-6", "dev-5", "dev-4", "dev-3"]);
+      expect(stats.tasks_by_department.map(({ id }) => id)).toEqual(["dev", "secretariat"]);
+    } finally {
+      db.close();
+    }
+  });
+
   it("서버 재시작 시 officePackProfiles가 있어도 seed agent를 대량 주입하지 않는다", () => {
     const db = setupDb();
     try {

--- a/server/modules/routes/ops/settings-stats.seed-init.test.ts
+++ b/server/modules/routes/ops/settings-stats.seed-init.test.ts
@@ -115,12 +115,22 @@ function createHarness(db: DatabaseSync) {
 }
 
 describe("ops settings seed init guard", () => {
-  it("GET /api/stats reports exactly the seven Notion-managed agents and their two departments", () => {
+  it("GET /api/stats reports exactly the seven Notion-managed agents and complete department catalog", () => {
     const db = setupDb();
     try {
-      for (const [id, order] of [["planning", 1], ["dev", 2], ["secretariat", 3], ["qa", 4]] as const) {
+      for (const [id, name, order] of [
+        ["planning", "Planning", 1],
+        ["representative", "代表", 101],
+        ["secretariat", "秘書室", 102],
+        ["marketing", "マーケティング部門", 103],
+        ["social", "SNS運用部門", 104],
+        ["sales", "営業部門", 105],
+        ["dev", "開発部門", 106],
+        ["backoffice", "バックオフィス部門", 107],
+        ["qa", "QA", 4],
+      ] as const) {
         db.prepare("INSERT INTO departments (id, name, name_ja, sort_order) VALUES (?, ?, ?, ?)")
-          .run(id, id, id === "dev" ? "🎨 開発部門" : id === "secretariat" ? "🧑‍💼 秘書室" : id, order);
+          .run(id, name, name, order);
       }
       const marker = (hex: string) => `hermes-member:${hex.repeat(64)}\n\nprofile`;
       for (const [index, name] of ["アポロン", "アイリス", "メティス", "ダイダロス", "アルゴス", "アテナ"].entries()) {
@@ -147,7 +157,15 @@ describe("ops settings seed init guard", () => {
       }).stats;
       expect(stats.agents).toEqual({ total: 7, working: 1, idle: 6 });
       expect(stats.top_agents.map(({ id }) => id)).toEqual(["hermes", "dev-6", "dev-5", "dev-4", "dev-3"]);
-      expect(stats.tasks_by_department.map(({ id }) => id)).toEqual(["dev", "secretariat"]);
+      expect(stats.tasks_by_department.map(({ id }) => id)).toEqual([
+        "representative",
+        "secretariat",
+        "marketing",
+        "social",
+        "sales",
+        "dev",
+        "backoffice",
+      ]);
     } finally {
       db.close();
     }

--- a/server/modules/routes/ops/settings-stats.ts
+++ b/server/modules/routes/ops/settings-stats.ts
@@ -4,6 +4,7 @@ import {
   encryptMessengerChannelsForStorage,
 } from "../../../messenger/token-crypto.ts";
 import { syncOfficePackAgentsForPack } from "../collab/office-pack-agent-hydration.ts";
+import { readNotionManagedDevelopmentScope } from "../../workflow/packs/notion-managed-development.ts";
 
 const MESSENGER_SETTINGS_KEY = "messengerChannels";
 const OFFICE_PACK_PROFILES_KEY = "officePackProfiles";
@@ -168,6 +169,20 @@ export function registerOpsSettingsStatsRoutes(ctx: RuntimeContext): void {
   });
 
   app.get("/api/stats", (_req, res) => {
+    const activePackRow = db.prepare("SELECT value FROM settings WHERE key = 'officeWorkflowPack' LIMIT 1").get() as
+      | { value?: unknown }
+      | undefined;
+    const activePack = normalizePackKey(activePackRow?.value) ?? "development";
+    const managedDevelopmentScope = activePack === "development"
+      ? readNotionManagedDevelopmentScope(db as any)
+      : null;
+    const managedAgentWhere = managedDevelopmentScope
+      ? `WHERE id IN (${managedDevelopmentScope.agentIds.map(() => "?").join(", ")})`
+      : "";
+    const managedAgentAnd = managedDevelopmentScope
+      ? `AND id IN (${managedDevelopmentScope.agentIds.map(() => "?").join(", ")})`
+      : "";
+    const managedAgentParams = managedDevelopmentScope?.agentIds ?? [];
     const totalTasks = (db.prepare("SELECT COUNT(*) as cnt FROM tasks").get() as { cnt: number }).cnt;
     const doneTasks = (db.prepare("SELECT COUNT(*) as cnt FROM tasks WHERE status = 'done'").get() as { cnt: number })
       .cnt;
@@ -197,14 +212,16 @@ export function registerOpsSettingsStatsRoutes(ctx: RuntimeContext): void {
       }
     ).cnt;
 
-    const totalAgents = (db.prepare("SELECT COUNT(*) as cnt FROM agents").get() as { cnt: number }).cnt;
+    const totalAgents = (
+      db.prepare(`SELECT COUNT(*) as cnt FROM agents ${managedAgentWhere}`).get(...managedAgentParams) as { cnt: number }
+    ).cnt;
     const workingAgents = (
-      db.prepare("SELECT COUNT(*) as cnt FROM agents WHERE status = 'working'").get() as {
+      db.prepare(`SELECT COUNT(*) as cnt FROM agents WHERE status = 'working' ${managedAgentAnd}`).get(...managedAgentParams) as {
         cnt: number;
       }
     ).cnt;
     const idleAgents = (
-      db.prepare("SELECT COUNT(*) as cnt FROM agents WHERE status = 'idle'").get() as {
+      db.prepare(`SELECT COUNT(*) as cnt FROM agents WHERE status = 'idle' ${managedAgentAnd}`).get(...managedAgentParams) as {
         cnt: number;
       }
     ).cnt;
@@ -212,13 +229,8 @@ export function registerOpsSettingsStatsRoutes(ctx: RuntimeContext): void {
     const completionRate = totalTasks > 0 ? Math.round((doneTasks / totalTasks) * 100) : 0;
 
     const topAgents = db
-      .prepare("SELECT id, name, avatar_emoji, stats_tasks_done, stats_xp FROM agents ORDER BY stats_xp DESC LIMIT 5")
-      .all();
-
-    const activePackRow = db.prepare("SELECT value FROM settings WHERE key = 'officeWorkflowPack' LIMIT 1").get() as
-      | { value?: unknown }
-      | undefined;
-    const activePack = normalizePackKey(activePackRow?.value) ?? "development";
+      .prepare(`SELECT id, name, avatar_emoji, stats_tasks_done, stats_xp FROM agents ${managedAgentWhere} ORDER BY stats_xp DESC LIMIT 5`)
+      .all(...managedAgentParams);
 
     let tasksByDept: unknown[];
     if (activePack !== "development") {
@@ -251,6 +263,10 @@ export function registerOpsSettingsStatsRoutes(ctx: RuntimeContext): void {
     }
 
     if (!Array.isArray(tasksByDept) || tasksByDept.length <= 0) {
+      const managedDepartmentIds = managedDevelopmentScope?.departmentIds ?? null;
+      const managedDepartmentClause = managedDepartmentIds
+        ? `WHERE d.id IN (${managedDepartmentIds.map(() => "?").join(", ")})`
+        : "";
       tasksByDept = db
         .prepare(
           `
@@ -261,11 +277,12 @@ export function registerOpsSettingsStatsRoutes(ctx: RuntimeContext): void {
       LEFT JOIN tasks t
         ON t.department_id = d.id
        AND COALESCE(t.workflow_pack_key, 'development') = 'development'
+      ${managedDepartmentClause}
       GROUP BY d.id
       ORDER BY d.sort_order ASC, d.id ASC
     `,
         )
-        .all();
+        .all(...(managedDepartmentIds ?? []));
     }
 
     const recentActivity = db

--- a/server/modules/routes/ops/worktrees-and-usage.test.ts
+++ b/server/modules/routes/ops/worktrees-and-usage.test.ts
@@ -75,7 +75,10 @@ function initRepo(basePrefix: string): string {
   return dir;
 }
 
-function createHarness(taskWorktrees: Map<string, { worktreePath: string; branchName: string; projectPath: string }>) {
+function createHarness(
+  taskWorktrees: Map<string, { worktreePath: string; branchName: string; projectPath: string }>,
+  restartTasks: Array<{ taskId: string; projectPath: string; hermes?: boolean; fingerprint?: string }> = [],
+) {
   const appendLogCalls: Array<{ taskId: string | null; kind: string; message: string }> = [];
   const getRoutes = new Map<string, RouteHandler>();
   const postRoutes = new Map<string, RouteHandler>();
@@ -119,6 +122,21 @@ function createHarness(taskWorktrees: Map<string, { worktreePath: string; branch
       }),
     );
   }
+  for (const task of restartTasks) {
+    db.prepare("INSERT INTO tasks (id, project_path, status, workflow_meta_json) VALUES (?, ?, 'review', ?)").run(
+      task.taskId,
+      task.projectPath,
+      task.hermes === false
+        ? null
+        : JSON.stringify({
+            hermes_execution: {
+              contract: "hermes-claw-execution/v2",
+              execution_id: HERMES_EXECUTION_ID,
+              request_fingerprint: task.fingerprint ?? HERMES_REQUEST_FINGERPRINT,
+            },
+          }),
+    );
+  }
   registerWorktreeAndUsageRoutes({
     app: app as any,
     taskWorktrees,
@@ -160,6 +178,98 @@ afterEach(() => {
 });
 
 describe("worktree verify-commit route", () => {
+  it("서버 재시작 후 디스크의 정확한 Hermes review worktree를 복구한다", () => {
+    const repo = initRepo("climpire-restart-recovery-");
+    tempDirs.push(repo);
+    const taskId = "d5cfce68-0be7-46f9-ad7c-76c0b6f6a8da";
+    const beforeRestart = new Map<string, { worktreePath: string; branchName: string; projectPath: string }>();
+    const tools = createWorktreeLifecycleTools({ appendTaskLog: () => {}, taskWorktrees: beforeRestart });
+    const worktreePath = tools.createWorktree(repo, taskId, "Athena");
+    expect(worktreePath).toBeTruthy();
+
+    const afterRestart = new Map<string, { worktreePath: string; branchName: string; projectPath: string }>();
+    const { db, getRoutes } = createHarness(afterRestart, [{ taskId, projectPath: repo }]);
+    try {
+      expect(afterRestart.get(taskId)).toEqual({
+        projectPath: repo,
+        worktreePath,
+        branchName: `climpire/${taskId.slice(0, 8)}`,
+      });
+
+      const listResponse = createFakeResponse();
+      getRoutes.get("/api/worktrees")?.({}, listResponse);
+      expect(listResponse.payload).toMatchObject({
+        ok: true,
+        worktrees: [{ taskId, projectPath: repo, worktreePath }],
+      });
+
+      const verifyResponse = createFakeResponse();
+      getRoutes.get("/api/tasks/:id/verify-commit")?.({ params: { id: taskId } }, verifyResponse);
+      expect(verifyResponse.payload).toMatchObject({
+        ok: true,
+        hasWorktree: true,
+        verdict: "no_commit",
+      });
+    } finally {
+      db.close();
+    }
+  }, 15_000);
+
+  it("Hermes 실행 표식이 없는 review worktree는 재시작 후 복구하지 않는다", () => {
+    const repo = initRepo("climpire-restart-non-hermes-");
+    tempDirs.push(repo);
+    const taskId = "a5cfce68-0be7-46f9-ad7c-76c0b6f6a8da";
+    const beforeRestart = new Map<string, { worktreePath: string; branchName: string; projectPath: string }>();
+    const tools = createWorktreeLifecycleTools({ appendTaskLog: () => {}, taskWorktrees: beforeRestart });
+    expect(tools.createWorktree(repo, taskId, "Athena")).toBeTruthy();
+
+    const afterRestart = new Map<string, { worktreePath: string; branchName: string; projectPath: string }>();
+    const { db } = createHarness(afterRestart, [{ taskId, projectPath: repo, hermes: false }]);
+    try {
+      expect(afterRestart.has(taskId)).toBe(false);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("같은 project와 short task id를 공유하는 Hermes review task들은 복구하지 않는다", () => {
+    const repo = initRepo("climpire-restart-collision-");
+    tempDirs.push(repo);
+    const firstTaskId = "b5cfce68-0be7-46f9-ad7c-76c0b6f6a8da";
+    const secondTaskId = "b5cfce68-1111-4222-8333-444444444444";
+    const beforeRestart = new Map<string, { worktreePath: string; branchName: string; projectPath: string }>();
+    const tools = createWorktreeLifecycleTools({ appendTaskLog: () => {}, taskWorktrees: beforeRestart });
+    expect(tools.createWorktree(repo, firstTaskId, "Athena")).toBeTruthy();
+
+    const afterRestart = new Map<string, { worktreePath: string; branchName: string; projectPath: string }>();
+    const { db } = createHarness(afterRestart, [
+      { taskId: firstTaskId, projectPath: repo },
+      { taskId: secondTaskId, projectPath: repo },
+    ]);
+    try {
+      expect(afterRestart.size).toBe(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("유효하지 않은 Hermes request fingerprint가 있는 review worktree는 복구하지 않는다", () => {
+    const repo = initRepo("climpire-restart-invalid-identity-");
+    tempDirs.push(repo);
+    const taskId = "c5cfce68-0be7-46f9-ad7c-76c0b6f6a8da";
+    const beforeRestart = new Map<string, { worktreePath: string; branchName: string; projectPath: string }>();
+    const tools = createWorktreeLifecycleTools({ appendTaskLog: () => {}, taskWorktrees: beforeRestart });
+    expect(tools.createWorktree(repo, taskId, "Athena")).toBeTruthy();
+
+    const afterRestart = new Map<string, { worktreePath: string; branchName: string; projectPath: string }>();
+    const { db } = createHarness(afterRestart, [{ taskId, projectPath: repo, fingerprint: "not-a-fingerprint" }]);
+    try {
+      expect(afterRestart.has(taskId)).toBe(false);
+    } finally {
+      db.close();
+    }
+  });
+
   it("worktree가 없으면 no_worktree 판정을 돌려준다", () => {
     const { db, getRoutes } = createHarness(new Map());
     try {

--- a/server/modules/routes/ops/worktrees-and-usage.test.ts
+++ b/server/modules/routes/ops/worktrees-and-usage.test.ts
@@ -6,9 +6,32 @@ import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { createWorktreeLifecycleTools } from "../../workflow/core/worktree/lifecycle.ts";
+import { releaseTaskWorktree, workspaceReleaseProofHash } from "../../workflow/core/worktree/release.ts";
 import { registerWorktreeAndUsageRoutes } from "./worktrees-and-usage.ts";
 
 type RouteHandler = (req: any, res: any) => any;
+
+const HERMES_EXECUTION_ID = "17d3c7d4-55dd-44b8-82e1-80d88ef2748a";
+const HERMES_REQUEST_FINGERPRINT = "a".repeat(64);
+
+function releaseRequest(
+  taskId: string,
+  proof: Record<string, unknown>,
+  authenticated = true,
+  identity = { executionId: HERMES_EXECUTION_ID, requestFingerprint: HERMES_REQUEST_FINGERPRINT },
+) {
+  return {
+    method: "POST",
+    params: { id: taskId },
+    body: {
+      ...proof,
+      executionId: identity.executionId,
+      requestFingerprint: identity.requestFingerprint,
+    },
+    header: (name: string) =>
+      authenticated && name.toLowerCase() === "authorization" ? "Bearer fixture-token" : undefined,
+  };
+}
 
 type FakeResponse = {
   statusCode: number;
@@ -68,6 +91,34 @@ function createHarness(taskWorktrees: Map<string, { worktreePath: string; branch
   };
 
   const db = new DatabaseSync(":memory:");
+  db.exec(`
+    CREATE TABLE tasks (
+      id TEXT PRIMARY KEY,
+      project_path TEXT,
+      status TEXT,
+      workflow_meta_json TEXT
+    );
+    CREATE TABLE task_logs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id TEXT,
+      kind TEXT,
+      message TEXT,
+      created_at INTEGER
+    );
+  `);
+  for (const [taskId, info] of taskWorktrees) {
+    db.prepare("INSERT INTO tasks (id, project_path, status, workflow_meta_json) VALUES (?, ?, 'review', ?)").run(
+      taskId,
+      info.projectPath,
+      JSON.stringify({
+        hermes_execution: {
+          contract: "hermes-claw-execution/v2",
+          execution_id: HERMES_EXECUTION_ID,
+          request_fingerprint: HERMES_REQUEST_FINGERPRINT,
+        },
+      }),
+    );
+  }
   registerWorktreeAndUsageRoutes({
     app: app as any,
     taskWorktrees,
@@ -75,6 +126,12 @@ function createHarness(taskWorktrees: Map<string, { worktreePath: string; branch
     cleanupWorktree: () => {},
     appendTaskLog: (taskId: string | null, kind: string, message: string) => {
       appendLogCalls.push({ taskId, kind, message });
+      db.prepare("INSERT INTO task_logs (task_id, kind, message, created_at) VALUES (?, ?, ?, ?)").run(
+        taskId,
+        kind,
+        message,
+        Date.now(),
+      );
     },
     resolveLang: () => "en",
     pickL: (value: string) => value,
@@ -186,6 +243,8 @@ describe("worktree verify-commit route", () => {
         hasWorktree: true,
         hasCommit: true,
         verdict: "ok",
+        worktreeHead: expect.stringMatching(/^[a-f0-9]{40}$/u),
+        savedHead: expect.stringMatching(/^[a-f0-9]{40}$/u),
       });
       expect(res.payload).toMatchObject({
         files: ["src/verify.ts"],
@@ -221,6 +280,300 @@ describe("worktree verify-commit route", () => {
 
       expect(res.statusCode).toBe(200);
       expect(appendLogCalls.some((entry) => entry.message.includes("Final branch verification: passed"))).toBe(true);
+    } finally {
+      db.close();
+      tools.cleanupWorktree(repo, taskId);
+    }
+  });
+
+  it("조건부 release를 기록하고 동일 요청 재시도에 같은 receipt를 돌려준다", () => {
+    const repo = initRepo("climpire-release-route-");
+    tempDirs.push(repo);
+    const taskId = "route001-0000-0000-0000-000000000000";
+    const taskWorktrees = new Map<string, { worktreePath: string; branchName: string; projectPath: string }>();
+    const tools = createWorktreeLifecycleTools({ appendTaskLog: () => {}, taskWorktrees });
+    const worktreePath = tools.createWorktree(repo, taskId, "Tester");
+    expect(worktreePath).toBeTruthy();
+
+    const { db, getRoutes, postRoutes, appendLogCalls } = createHarness(taskWorktrees);
+    try {
+      const verify = createFakeResponse();
+      getRoutes.get("/api/tasks/:id/verify-commit")?.({ params: { id: taskId } }, verify);
+      const verification = verify.payload as Record<string, unknown>;
+      const body = {
+        mode: "no_local_changes",
+        projectPath: repo,
+        worktreePath,
+        branchName: verification.branchName,
+        worktreeHead: verification.worktreeHead,
+        savedRef: verification.compareRef,
+        savedHead: verification.savedHead,
+      };
+      const handler = postRoutes.get("/api/tasks/:id/release-worktree");
+      expect(handler).toBeTypeOf("function");
+
+      const first = createFakeResponse();
+      handler?.(releaseRequest(taskId, body), first);
+      expect(first.statusCode).toBe(200);
+      expect(first.payload).toMatchObject({
+        ok: true,
+        replayed: false,
+        receipt: {
+          taskId,
+          mode: "no_local_changes",
+          worktreeReleased: true,
+          proofHash: expect.stringMatching(/^[a-f0-9]{64}$/u),
+        },
+      });
+      expect(fs.existsSync(String(worktreePath))).toBe(false);
+      expect(taskWorktrees.has(taskId)).toBe(false);
+      expect(appendLogCalls.filter((entry) => entry.message.startsWith("Workspace release receipt: "))).toHaveLength(1);
+
+      const second = createFakeResponse();
+      handler?.(releaseRequest(taskId, body), second);
+      expect(second.statusCode).toBe(200);
+      expect(second.payload).toMatchObject({ ok: true, replayed: true, receipt: (first.payload as any).receipt });
+      expect(appendLogCalls.filter((entry) => entry.message.startsWith("Workspace release receipt: "))).toHaveLength(1);
+
+      const nextIdentity = {
+        executionId: "27d3c7d4-55dd-44b8-82e1-80d88ef2748a",
+        requestFingerprint: "b".repeat(64),
+      };
+      db.prepare("UPDATE tasks SET workflow_meta_json = ? WHERE id = ?").run(
+        JSON.stringify({
+          hermes_execution: {
+            contract: "hermes-claw-execution/v2",
+            execution_id: nextIdentity.executionId,
+            request_fingerprint: nextIdentity.requestFingerprint,
+          },
+        }),
+        taskId,
+      );
+      const nextWorktreePath = String(tools.createWorktree(repo, taskId, "Tester"));
+      const nextVerify = createFakeResponse();
+      getRoutes.get("/api/tasks/:id/verify-commit")?.({ params: { id: taskId } }, nextVerify);
+      const nextVerification = nextVerify.payload as Record<string, unknown>;
+      const next = createFakeResponse();
+      handler?.(
+        releaseRequest(
+          taskId,
+          {
+            mode: "no_local_changes",
+            projectPath: repo,
+            worktreePath: nextWorktreePath,
+            branchName: nextVerification.branchName,
+            worktreeHead: nextVerification.worktreeHead,
+            savedRef: nextVerification.compareRef,
+            savedHead: nextVerification.savedHead,
+          },
+          true,
+          nextIdentity,
+        ),
+        next,
+      );
+      expect(next.statusCode).toBe(200);
+      expect(next.payload).toMatchObject({
+        ok: true,
+        replayed: false,
+        receipt: { executionId: nextIdentity.executionId, requestFingerprint: nextIdentity.requestFingerprint },
+      });
+      expect(fs.existsSync(nextWorktreePath)).toBe(false);
+      expect(appendLogCalls.filter((entry) => entry.message.startsWith("Workspace release receipt: "))).toHaveLength(2);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("dirty 또는 저장 증거가 다른 release 요청은 zero-delete로 거부한다", () => {
+    const repo = initRepo("climpire-release-route-reject-");
+    tempDirs.push(repo);
+    const taskId = "route002-0000-0000-0000-000000000000";
+    const taskWorktrees = new Map<string, { worktreePath: string; branchName: string; projectPath: string }>();
+    const tools = createWorktreeLifecycleTools({ appendTaskLog: () => {}, taskWorktrees });
+    const worktreePath = String(tools.createWorktree(repo, taskId, "Tester"));
+    fs.writeFileSync(path.join(worktreePath, "unsaved.txt"), "unsaved\n");
+
+    const { db, getRoutes, postRoutes } = createHarness(taskWorktrees);
+    try {
+      const verify = createFakeResponse();
+      getRoutes.get("/api/tasks/:id/verify-commit")?.({ params: { id: taskId } }, verify);
+      const verification = verify.payload as Record<string, unknown>;
+      const res = createFakeResponse();
+      postRoutes.get("/api/tasks/:id/release-worktree")?.(
+        releaseRequest(taskId, {
+          mode: "no_local_changes",
+          projectPath: repo,
+          worktreePath,
+          branchName: verification.branchName,
+          worktreeHead: verification.worktreeHead,
+          savedRef: verification.compareRef,
+          savedHead: verification.savedHead,
+        }),
+        res,
+      );
+
+      expect(res.statusCode).toBe(409);
+      expect(res.payload).toMatchObject({ ok: false, error: "workspace_dirty" });
+      expect(fs.existsSync(worktreePath)).toBe(true);
+      expect(taskWorktrees.has(taskId)).toBe(true);
+    } finally {
+      db.close();
+      tools.cleanupWorktree(repo, taskId);
+    }
+  });
+
+  it("prepared 뒤 응답이 끊긴 release를 read-back하고 receipt로 수렴시킨다", () => {
+    const repo = initRepo("climpire-release-route-reconcile-");
+    tempDirs.push(repo);
+    const taskId = "route003-0000-0000-0000-000000000000";
+    const taskWorktrees = new Map<string, { worktreePath: string; branchName: string; projectPath: string }>();
+    const tools = createWorktreeLifecycleTools({ appendTaskLog: () => {}, taskWorktrees });
+    const worktreePath = String(tools.createWorktree(repo, taskId, "Tester"));
+    const mapped = taskWorktrees.get(taskId)!;
+    const { db, getRoutes, postRoutes, appendLogCalls } = createHarness(taskWorktrees);
+    try {
+      const verify = createFakeResponse();
+      getRoutes.get("/api/tasks/:id/verify-commit")?.({ params: { id: taskId } }, verify);
+      const verification = verify.payload as Record<string, unknown>;
+      const proof = {
+        executionId: HERMES_EXECUTION_ID,
+        requestFingerprint: HERMES_REQUEST_FINGERPRINT,
+        mode: "no_local_changes" as const,
+        projectPath: repo,
+        worktreePath,
+        branchName: String(verification.branchName),
+        worktreeHead: String(verification.worktreeHead),
+        savedRef: String(verification.compareRef),
+        savedHead: String(verification.savedHead),
+      };
+      const hash = workspaceReleaseProofHash(taskId, proof);
+      db.prepare("INSERT INTO task_logs (task_id, kind, message, created_at) VALUES (?, ?, ?, ?)").run(
+        taskId,
+        "system",
+        `Workspace release prepared: ${JSON.stringify({ taskId, proofHash: hash, proof })}`,
+        Date.now(),
+      );
+      releaseTaskWorktree({
+        taskId,
+        taskProjectPath: repo,
+        mappedWorktree: mapped,
+        proof,
+        taskWorktrees,
+      });
+
+      const res = createFakeResponse();
+      postRoutes.get("/api/tasks/:id/release-worktree")?.(releaseRequest(taskId, proof), res);
+
+      expect(res.statusCode, JSON.stringify(res.payload)).toBe(200);
+      expect(res.payload).toMatchObject({
+        ok: true,
+        replayed: true,
+        reconciled: true,
+        receipt: { proofHash: hash, worktreeReleased: true },
+      });
+      expect(appendLogCalls.filter((entry) => entry.message.startsWith("Workspace release receipt: "))).toHaveLength(1);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("failed dirty proof cannot become a receipt after explicit discard", () => {
+    const repo = initRepo("climpire-release-dirty-discard-");
+    tempDirs.push(repo);
+    const taskId = "route004-0000-0000-0000-000000000000";
+    const taskWorktrees = new Map<string, { worktreePath: string; branchName: string; projectPath: string }>();
+    const tools = createWorktreeLifecycleTools({ appendTaskLog: () => {}, taskWorktrees });
+    const worktreePath = String(tools.createWorktree(repo, taskId, "Tester"));
+    const { db, getRoutes, postRoutes } = createHarness(taskWorktrees);
+    try {
+      const verify = createFakeResponse();
+      getRoutes.get("/api/tasks/:id/verify-commit")?.({ params: { id: taskId } }, verify);
+      const verification = verify.payload as Record<string, unknown>;
+      const proof = {
+        executionId: HERMES_EXECUTION_ID,
+        requestFingerprint: HERMES_REQUEST_FINGERPRINT,
+        mode: "no_local_changes" as const,
+        projectPath: repo,
+        worktreePath,
+        branchName: String(verification.branchName),
+        worktreeHead: String(verification.worktreeHead),
+        savedRef: String(verification.compareRef),
+        savedHead: String(verification.savedHead),
+      };
+      fs.writeFileSync(path.join(worktreePath, "dirty.txt"), "dirty\n");
+      const first = createFakeResponse();
+      postRoutes.get("/api/tasks/:id/release-worktree")?.(releaseRequest(taskId, proof), first);
+      expect(first.statusCode).toBe(409);
+      expect(
+        db.prepare("SELECT COUNT(*) AS count FROM task_logs WHERE message LIKE 'Workspace release prepared:%'").get(),
+      ).toMatchObject({ count: 0 });
+
+      fs.unlinkSync(path.join(worktreePath, "dirty.txt"));
+      const hash = workspaceReleaseProofHash(taskId, proof);
+      db.prepare("INSERT INTO task_logs (task_id, kind, message, created_at) VALUES (?, 'system', ?, ?)").run(
+        taskId,
+        `Workspace release prepared: ${JSON.stringify({ taskId, proofHash: hash, proof })}`,
+        Date.now(),
+      );
+      tools.cleanupWorktree(repo, taskId);
+      db.prepare("INSERT INTO task_logs (task_id, kind, message, created_at) VALUES (?, 'system', ?, ?)").run(
+        taskId,
+        "Worktree discarded (changes abandoned)",
+        Date.now(),
+      );
+      const second = createFakeResponse();
+      postRoutes.get("/api/tasks/:id/release-worktree")?.(releaseRequest(taskId, proof), second);
+      expect(second.statusCode).toBe(409);
+      expect(second.payload).toMatchObject({ error: "workspace_release_not_reconcilable" });
+      expect(
+        db.prepare("SELECT COUNT(*) AS count FROM task_logs WHERE message LIKE 'Workspace release receipt:%'").get(),
+      ).toMatchObject({ count: 0 });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("rejects missing CSRF, mismatched task identity, and non-review task state before release", () => {
+    const repo = initRepo("climpire-release-auth-");
+    tempDirs.push(repo);
+    const taskId = "route005-0000-0000-0000-000000000000";
+    const taskWorktrees = new Map<string, { worktreePath: string; branchName: string; projectPath: string }>();
+    const tools = createWorktreeLifecycleTools({ appendTaskLog: () => {}, taskWorktrees });
+    const worktreePath = String(tools.createWorktree(repo, taskId, "Tester"));
+    const { db, getRoutes, postRoutes } = createHarness(taskWorktrees);
+    try {
+      const verify = createFakeResponse();
+      getRoutes.get("/api/tasks/:id/verify-commit")?.({ params: { id: taskId } }, verify);
+      const verification = verify.payload as Record<string, unknown>;
+      const proof = {
+        mode: "no_local_changes",
+        projectPath: repo,
+        worktreePath,
+        branchName: verification.branchName,
+        worktreeHead: verification.worktreeHead,
+        savedRef: verification.compareRef,
+        savedHead: verification.savedHead,
+      };
+      const handler = postRoutes.get("/api/tasks/:id/release-worktree");
+
+      const noCsrf = createFakeResponse();
+      handler?.(releaseRequest(taskId, proof, false), noCsrf);
+      expect(noCsrf.statusCode).toBe(403);
+      expect(noCsrf.payload).toMatchObject({ error: "csrf_token_invalid" });
+
+      const wrongIdentity = createFakeResponse();
+      const request = releaseRequest(taskId, proof);
+      request.body.executionId = "different-execution";
+      handler?.(request, wrongIdentity);
+      expect(wrongIdentity.statusCode).toBe(403);
+      expect(wrongIdentity.payload).toMatchObject({ error: "task_identity_mismatch" });
+
+      db.prepare("UPDATE tasks SET status = 'in_progress' WHERE id = ?").run(taskId);
+      const wrongState = createFakeResponse();
+      handler?.(releaseRequest(taskId, proof), wrongState);
+      expect(wrongState.statusCode).toBe(409);
+      expect(wrongState.payload).toMatchObject({ error: "task_not_releasable" });
+      expect(fs.existsSync(worktreePath)).toBe(true);
     } finally {
       db.close();
       tools.cleanupWorktree(repo, taskId);

--- a/server/modules/routes/ops/worktrees-and-usage.ts
+++ b/server/modules/routes/ops/worktrees-and-usage.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
+import path from "node:path";
 import type { RuntimeContext } from "../../../types/runtime-context.ts";
 import { hasValidCsrfToken, shouldRequireCsrf } from "../../../security/auth.ts";
 import type { CliUsageEntry } from "../shared/types.ts";
@@ -15,6 +16,8 @@ import {
 
 const WORKSPACE_RELEASE_RECEIPT_PREFIX = "Workspace release receipt: ";
 const WORKSPACE_RELEASE_PREPARED_PREFIX = "Workspace release prepared: ";
+const WORKTREE_RECOVERY_BUDGET_MS = 8000;
+const WORKTREE_RECOVERY_MAX_TASKS = 256;
 
 function readHermesTaskIdentity(value: unknown): { executionId: string; requestFingerprint: string } | null {
   if (typeof value !== "string" || !value.trim()) return null;
@@ -26,7 +29,10 @@ function readHermesTaskIdentity(value: unknown): { executionId: string; requestF
     if (
       (marker?.contract !== "hermes-claw-execution/v1" && marker?.contract !== "hermes-claw-execution/v2") ||
       typeof marker.execution_id !== "string" ||
-      typeof marker.request_fingerprint !== "string"
+      !marker.execution_id ||
+      marker.execution_id.trim() !== marker.execution_id ||
+      typeof marker.request_fingerprint !== "string" ||
+      !/^[a-f0-9]{64}$/u.test(marker.request_fingerprint)
     ) {
       return null;
     }
@@ -60,6 +66,185 @@ function refExists(cwd: string, ref: string): boolean {
     return true;
   } catch {
     return false;
+  }
+}
+
+type RecoverableTaskRow = {
+  id: string;
+  project_path: string | null;
+  workflow_meta_json: string | null;
+};
+
+type PorcelainWorktree = {
+  worktreePath: string;
+  head: string | null;
+  branchRef: string | null;
+};
+
+type RecoveryCandidate = {
+  taskId: string;
+  projectPath: string;
+  canonicalProjectPath: string;
+  shortId: string;
+};
+
+function parseWorktreeListPorcelain(value: string): PorcelainWorktree[] {
+  return value
+    .split(/\n\s*\n/u)
+    .map((block) => {
+      const lines = block.split("\n");
+      const worktreeLine = lines.find((line) => line.startsWith("worktree "));
+      if (!worktreeLine) return null;
+      const headLine = lines.find((line) => line.startsWith("HEAD "));
+      const branchLine = lines.find((line) => line.startsWith("branch "));
+      return {
+        worktreePath: worktreeLine.slice("worktree ".length),
+        head: headLine ? headLine.slice("HEAD ".length) : null,
+        branchRef: branchLine ? branchLine.slice("branch ".length) : null,
+      };
+    })
+    .filter((entry): entry is PorcelainWorktree => Boolean(entry));
+}
+
+function recoverHermesReviewWorktrees(
+  db: RuntimeContext["db"],
+  taskWorktrees: RuntimeContext["taskWorktrees"],
+): void {
+  let tasks: RecoverableTaskRow[];
+  try {
+    tasks = db
+      .prepare(
+        "SELECT id, project_path, workflow_meta_json FROM tasks WHERE status = 'review' AND workflow_meta_json LIKE '%\"hermes_execution\"%' LIMIT ?",
+      )
+      .all(WORKTREE_RECOVERY_MAX_TASKS + 1) as RecoverableTaskRow[];
+  } catch {
+    return;
+  }
+  if (tasks.length > WORKTREE_RECOVERY_MAX_TASKS) return;
+
+  const candidates: RecoveryCandidate[] = [];
+  for (const task of tasks) {
+    if (!task.project_path || !readHermesTaskIdentity(task.workflow_meta_json)) continue;
+    const shortId = task.id.slice(0, 8);
+    if (!/^[a-f0-9]{8}$/u.test(shortId) || !path.isAbsolute(task.project_path)) continue;
+    try {
+      const projectPath = path.resolve(task.project_path);
+      candidates.push({
+        taskId: task.id,
+        projectPath,
+        canonicalProjectPath: fs.realpathSync(projectPath),
+        shortId,
+      });
+    } catch {
+      // Invalid project paths are not recoverable.
+    }
+  }
+
+  const ownershipGroups = new Map<string, RecoveryCandidate[]>();
+  for (const candidate of candidates) {
+    const key = `${candidate.canonicalProjectPath}\0${candidate.shortId}`;
+    const group = ownershipGroups.get(key) ?? [];
+    group.push(candidate);
+    ownershipGroups.set(key, group);
+  }
+
+  const claimedPaths = new Set<string>();
+  const claimedBranches = new Set<string>();
+  for (const info of taskWorktrees.values()) {
+    let canonicalProjectPath: string;
+    try {
+      canonicalProjectPath = fs.realpathSync(path.resolve(info.projectPath));
+      claimedBranches.add(`${canonicalProjectPath}\0${info.branchName}`);
+    } catch {
+      continue;
+    }
+    try {
+      claimedPaths.add(fs.realpathSync(path.resolve(info.worktreePath)));
+    } catch {
+      // A missing mapped path still owns its project-scoped branch name.
+    }
+  }
+
+  const deadline = Date.now() + WORKTREE_RECOVERY_BUDGET_MS;
+  const projectCache = new Map<string, PorcelainWorktree[] | null>();
+  const inspectProject = (canonicalProjectPath: string): PorcelainWorktree[] | null => {
+    if (projectCache.has(canonicalProjectPath)) return projectCache.get(canonicalProjectPath) ?? null;
+    const runBounded = (args: string[], capMs: number): string | null => {
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) return null;
+      try {
+        return execFileSync("git", args, {
+          cwd: canonicalProjectPath,
+          stdio: "pipe",
+          timeout: Math.max(1, Math.min(capMs, remainingMs)),
+        }).toString();
+      } catch {
+        return null;
+      }
+    };
+
+    const topLevelOutput = runBounded(["rev-parse", "--show-toplevel"], 2500);
+    if (!topLevelOutput) {
+      projectCache.set(canonicalProjectPath, null);
+      return null;
+    }
+    try {
+      if (fs.realpathSync(topLevelOutput.trim()) !== canonicalProjectPath) {
+        projectCache.set(canonicalProjectPath, null);
+        return null;
+      }
+    } catch {
+      projectCache.set(canonicalProjectPath, null);
+      return null;
+    }
+
+    const worktreeOutput = runBounded(["worktree", "list", "--porcelain"], 4000);
+    const worktrees = worktreeOutput ? parseWorktreeListPorcelain(worktreeOutput) : null;
+    projectCache.set(canonicalProjectPath, worktrees);
+    return worktrees;
+  };
+
+  for (const group of ownershipGroups.values()) {
+    if (group.length !== 1 || Date.now() >= deadline) continue;
+    const candidate = group[0]!;
+    if (taskWorktrees.has(candidate.taskId)) continue;
+
+    try {
+      const worktrees = inspectProject(candidate.canonicalProjectPath);
+      if (!worktrees) continue;
+      const matches = worktrees.filter((entry) => {
+        for (let suffix = 0; suffix <= 3; suffix += 1) {
+          const suffixText = suffix === 0 ? "" : `-${suffix}`;
+          const expectedPath = path.join(
+            candidate.canonicalProjectPath,
+            ".climpire-worktrees",
+            `${candidate.shortId}${suffixText}`,
+          );
+          const expectedBranchRef = `refs/heads/climpire/${candidate.shortId}${suffixText}`;
+          if (path.resolve(entry.worktreePath) !== expectedPath || entry.branchRef !== expectedBranchRef) continue;
+          if (!fs.existsSync(expectedPath) || fs.realpathSync(expectedPath) !== expectedPath) return false;
+          return /^[a-f0-9]{40}$/u.test(entry.head ?? "");
+        }
+        return false;
+      });
+      if (matches.length !== 1) continue;
+
+      const match = matches[0]!;
+      const canonicalWorktreePath = fs.realpathSync(match.worktreePath);
+      const branchName = match.branchRef!.slice("refs/heads/".length);
+      const branchKey = `${candidate.canonicalProjectPath}\0${branchName}`;
+      if (claimedPaths.has(canonicalWorktreePath) || claimedBranches.has(branchKey)) continue;
+
+      taskWorktrees.set(candidate.taskId, {
+        projectPath: candidate.projectPath,
+        worktreePath: path.join(candidate.projectPath, ".climpire-worktrees", path.basename(match.worktreePath)),
+        branchName: match.branchRef!.slice("refs/heads/".length),
+      });
+      claimedPaths.add(canonicalWorktreePath);
+      claimedBranches.add(branchKey);
+    } catch {
+      // Recovery is fail-closed: malformed or ambiguous disk state remains unmapped.
+    }
   }
 }
 
@@ -220,6 +405,7 @@ export function registerWorktreeAndUsageRoutes(ctx: RuntimeContext): {
     broadcast,
   } = ctx;
   const workspaceReleaseInFlight = new Set<string>();
+  recoverHermesReviewWorktrees(db, taskWorktrees);
 
   app.get("/api/tasks/:id/diff", (req, res) => {
     const id = String(req.params.id);

--- a/server/modules/routes/ops/worktrees-and-usage.ts
+++ b/server/modules/routes/ops/worktrees-and-usage.ts
@@ -1,6 +1,40 @@
 import { execFileSync } from "node:child_process";
+import fs from "node:fs";
 import type { RuntimeContext } from "../../../types/runtime-context.ts";
+import { hasValidCsrfToken, shouldRequireCsrf } from "../../../security/auth.ts";
 import type { CliUsageEntry } from "../shared/types.ts";
+import {
+  WorkspaceReleaseError,
+  reconcileReleasedTaskWorktree,
+  releaseTaskWorktree,
+  workspaceReleaseProofHash,
+  workspaceReleaseReceiptMatches,
+  type WorkspaceReleaseProof,
+  type WorkspaceReleaseReceipt,
+} from "../../workflow/core/worktree/release.ts";
+
+const WORKSPACE_RELEASE_RECEIPT_PREFIX = "Workspace release receipt: ";
+const WORKSPACE_RELEASE_PREPARED_PREFIX = "Workspace release prepared: ";
+
+function readHermesTaskIdentity(value: unknown): { executionId: string; requestFingerprint: string } | null {
+  if (typeof value !== "string" || !value.trim()) return null;
+  try {
+    const root = JSON.parse(value) as {
+      hermes_execution?: { contract?: unknown; execution_id?: unknown; request_fingerprint?: unknown };
+    };
+    const marker = root.hermes_execution;
+    if (
+      (marker?.contract !== "hermes-claw-execution/v1" && marker?.contract !== "hermes-claw-execution/v2") ||
+      typeof marker.execution_id !== "string" ||
+      typeof marker.request_fingerprint !== "string"
+    ) {
+      return null;
+    }
+    return { executionId: marker.execution_id, requestFingerprint: marker.request_fingerprint };
+  } catch {
+    return null;
+  }
+}
 
 function readGitLines(cwd: string, args: string[], timeout = 8000): string[] {
   const output = execFileSync("git", args, { cwd, stdio: "pipe", timeout }).toString().trim();
@@ -41,13 +75,18 @@ function resolveCompareRef(projectPath: string, worktreePath: string): string | 
       .toString()
       .trim();
     if (currentBranch && currentBranch !== "HEAD") {
-      preferredCandidates.push(`origin/${currentBranch}`, currentBranch);
+      preferredCandidates.push(`refs/heads/${currentBranch}`, `refs/remotes/origin/${currentBranch}`);
     }
   } catch {
     // ignore and fall back to generic candidates
   }
 
-  preferredCandidates.push("origin/main", "main", "origin/master", "master");
+  preferredCandidates.push(
+    "refs/heads/main",
+    "refs/remotes/origin/main",
+    "refs/heads/master",
+    "refs/remotes/origin/master",
+  );
 
   for (const candidate of preferredCandidates) {
     if (refExists(worktreePath, candidate)) return candidate;
@@ -78,6 +117,8 @@ type VerifyCommitState = {
   worktreePath: string | null;
   branchName?: string;
   compareRef: string | null;
+  worktreeHead: string | null;
+  savedHead: string | null;
   hasCommit: boolean;
   commitCount: number;
   commits: string[];
@@ -100,6 +141,8 @@ function inspectWorktreeVerification(wtInfo?: {
       hasWorktree: false,
       worktreePath: null,
       compareRef: null,
+      worktreeHead: null,
+      savedHead: null,
       hasCommit: false,
       commitCount: 0,
       commits: [],
@@ -112,6 +155,10 @@ function inspectWorktreeVerification(wtInfo?: {
   }
 
   const compareRef = resolveCompareRef(wtInfo.projectPath, worktreePath);
+  const worktreeHead = tryReadGitLines(worktreePath, ["rev-parse", "HEAD"])[0] ?? null;
+  const savedHead = compareRef
+    ? (tryReadGitLines(wtInfo.projectPath, ["rev-parse", "--verify", compareRef])[0] ?? null)
+    : null;
   const commits = compareRef ? readGitLines(worktreePath, ["log", `${compareRef}..HEAD`, "--oneline"]) : [];
   const changedFiles = (
     compareRef ? tryReadGitLines(worktreePath, ["diff", `${compareRef}..HEAD`, "--name-only"]) : []
@@ -138,6 +185,8 @@ function inspectWorktreeVerification(wtInfo?: {
     worktreePath,
     branchName: wtInfo.branchName,
     compareRef,
+    worktreeHead,
+    savedHead,
     hasCommit: commits.length > 0,
     commitCount: commits.length,
     commits,
@@ -170,6 +219,7 @@ export function registerWorktreeAndUsageRoutes(ctx: RuntimeContext): {
     fetchGeminiUsage,
     broadcast,
   } = ctx;
+  const workspaceReleaseInFlight = new Set<string>();
 
   app.get("/api/tasks/:id/diff", (req, res) => {
     const id = String(req.params.id);
@@ -295,6 +345,160 @@ export function registerWorktreeAndUsageRoutes(ctx: RuntimeContext): {
     );
 
     res.json({ ok: true, message: "Worktree discarded" });
+  });
+
+  app.post("/api/tasks/:id/release-worktree", (req, res) => {
+    const id = String(req.params.id);
+    if (shouldRequireCsrf(req) && !hasValidCsrfToken(req)) {
+      return res.status(403).json({ ok: false, error: "csrf_token_invalid" });
+    }
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const proof: WorkspaceReleaseProof = {
+      executionId: typeof body.executionId === "string" ? body.executionId : "",
+      requestFingerprint: typeof body.requestFingerprint === "string" ? body.requestFingerprint : "",
+      mode: body.mode as WorkspaceReleaseProof["mode"],
+      projectPath: typeof body.projectPath === "string" ? body.projectPath : "",
+      worktreePath: typeof body.worktreePath === "string" ? body.worktreePath : "",
+      branchName: typeof body.branchName === "string" ? body.branchName : "",
+      worktreeHead: typeof body.worktreeHead === "string" ? body.worktreeHead : "",
+      savedRef: typeof body.savedRef === "string" ? body.savedRef : "",
+      savedHead: typeof body.savedHead === "string" ? body.savedHead : "",
+    };
+    if (
+      !["no_local_changes", "git_saved"].includes(proof.mode) ||
+      !proof.executionId ||
+      !/^[a-f0-9]{64}$/u.test(proof.requestFingerprint) ||
+      !proof.projectPath ||
+      !proof.worktreePath ||
+      !proof.branchName ||
+      !/^[a-f0-9]{40}$/u.test(proof.worktreeHead) ||
+      !/^refs\/heads\/[A-Za-z0-9][A-Za-z0-9._/-]*$/u.test(proof.savedRef) ||
+      proof.savedRef.includes("..") ||
+      proof.savedRef === `refs/heads/${proof.branchName}` ||
+      !/^[a-f0-9]{40}$/u.test(proof.savedHead)
+    ) {
+      return res.status(400).json({ ok: false, error: "workspace_release_request_invalid" });
+    }
+
+    const task = db.prepare("SELECT id, project_path, status, workflow_meta_json FROM tasks WHERE id = ?").get(id) as
+      | { id: string; project_path: string | null; status: string; workflow_meta_json: string | null }
+      | undefined;
+    if (!task?.project_path) {
+      return res.status(404).json({ ok: false, error: "task_or_project_not_found" });
+    }
+    const identity = readHermesTaskIdentity(task.workflow_meta_json);
+    if (!identity || task.status !== "review") {
+      return res.status(409).json({ ok: false, error: "task_not_releasable" });
+    }
+    if (identity.executionId !== proof.executionId || identity.requestFingerprint !== proof.requestFingerprint) {
+      return res.status(403).json({ ok: false, error: "task_identity_mismatch" });
+    }
+    if (workspaceReleaseInFlight.has(id)) {
+      return res.status(409).json({ ok: false, error: "workspace_release_in_progress" });
+    }
+    workspaceReleaseInFlight.add(id);
+
+    try {
+      const hash = workspaceReleaseProofHash(id, proof);
+      const rows = db
+        .prepare("SELECT message FROM task_logs WHERE task_id = ? AND message LIKE ? ORDER BY rowid DESC LIMIT 20")
+        .all(id, `${WORKSPACE_RELEASE_RECEIPT_PREFIX}%`) as Array<{ message: string }>;
+      for (const row of rows) {
+        try {
+          const receipt = JSON.parse(
+            row.message.slice(WORKSPACE_RELEASE_RECEIPT_PREFIX.length),
+          ) as WorkspaceReleaseReceipt;
+          if (workspaceReleaseReceiptMatches(id, proof, receipt)) {
+            return res.json({ ok: true, replayed: true, receipt });
+          }
+        } catch {
+          // Ignore unrelated legacy log text.
+        }
+      }
+
+      const preparedRows = db
+        .prepare(
+          "SELECT rowid AS log_rowid, message FROM task_logs WHERE task_id = ? AND message LIKE ? ORDER BY rowid DESC LIMIT 20",
+        )
+        .all(id, `${WORKSPACE_RELEASE_PREPARED_PREFIX}%`) as Array<{ log_rowid: number; message: string }>;
+      const prepared = preparedRows.find((row) => {
+        try {
+          const value = JSON.parse(row.message.slice(WORKSPACE_RELEASE_PREPARED_PREFIX.length)) as {
+            proofHash?: unknown;
+          };
+          return value.proofHash === hash;
+        } catch {
+          return false;
+        }
+      });
+      if (prepared && !fs.existsSync(proof.worktreePath)) {
+        const explicitDiscard = db
+          .prepare(
+            "SELECT 1 FROM task_logs WHERE task_id = ? AND rowid > ? AND message LIKE 'Worktree discarded%' LIMIT 1",
+          )
+          .get(id, prepared.log_rowid);
+        if (explicitDiscard) {
+          return res.status(409).json({ ok: false, error: "workspace_release_not_reconcilable" });
+        }
+      }
+
+      let reconciled = false;
+      let receipt: WorkspaceReleaseReceipt;
+      if (prepared && !fs.existsSync(proof.worktreePath)) {
+        receipt = reconcileReleasedTaskWorktree({
+          taskId: id,
+          taskProjectPath: task.project_path,
+          mappedWorktree: taskWorktrees.get(id),
+          proof,
+          taskWorktrees,
+        });
+        reconciled = true;
+      } else {
+        const preparedMessage = `${WORKSPACE_RELEASE_PREPARED_PREFIX}${JSON.stringify({
+          taskId: id,
+          executionId: proof.executionId,
+          requestFingerprint: proof.requestFingerprint,
+          proofHash: hash,
+          proof,
+        })}`;
+        receipt = releaseTaskWorktree({
+          taskId: id,
+          taskProjectPath: task.project_path,
+          mappedWorktree: taskWorktrees.get(id),
+          proof,
+          taskWorktrees,
+          beforeMutation: prepared
+            ? undefined
+            : () => {
+                appendTaskLog(id, "system", preparedMessage);
+                const stored = db
+                  .prepare("SELECT 1 FROM task_logs WHERE task_id = ? AND message = ? ORDER BY rowid DESC LIMIT 1")
+                  .get(id, preparedMessage);
+                if (!stored) {
+                  throw new WorkspaceReleaseError(
+                    "workspace_release_prepare_not_persisted",
+                    "Workspace release mutation marker was not persisted",
+                  );
+                }
+              },
+        });
+      }
+      appendTaskLog(id, "system", `${WORKSPACE_RELEASE_RECEIPT_PREFIX}${JSON.stringify(receipt)}`);
+      const stored = db
+        .prepare("SELECT message FROM task_logs WHERE task_id = ? AND message = ? ORDER BY created_at DESC LIMIT 1")
+        .get(id, `${WORKSPACE_RELEASE_RECEIPT_PREFIX}${JSON.stringify(receipt)}`) as { message: string } | undefined;
+      if (!stored) {
+        return res.status(500).json({ ok: false, error: "workspace_release_receipt_not_persisted" });
+      }
+      return res.json({ ok: true, replayed: Boolean(prepared), reconciled, receipt });
+    } catch (error) {
+      if (error instanceof WorkspaceReleaseError) {
+        return res.status(409).json({ ok: false, error: error.code });
+      }
+      return res.status(500).json({ ok: false, error: "workspace_release_failed" });
+    } finally {
+      workspaceReleaseInFlight.delete(id);
+    }
   });
 
   app.get("/api/tasks/:id/verify-commit", (req, res) => {

--- a/server/modules/workflow/core/worktree/release.test.ts
+++ b/server/modules/workflow/core/worktree/release.test.ts
@@ -1,0 +1,266 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  WorkspaceReleaseError,
+  releaseTaskWorktree,
+  workspaceReleaseReceiptMatches,
+  type WorkspaceReleaseProof,
+} from "./release.ts";
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
+
+function fixture() {
+  const projectPath = fs.mkdtempSync(path.join(os.tmpdir(), "climpire-safe-release-"));
+  git(projectPath, ["init", "-b", "main"]);
+  git(projectPath, ["config", "user.name", "Claw Release Test"]);
+  git(projectPath, ["config", "user.email", "claw-release@example.test"]);
+  fs.writeFileSync(path.join(projectPath, "README.md"), "seed\n");
+  git(projectPath, ["add", "README.md"]);
+  git(projectPath, ["commit", "-m", "seed"]);
+
+  const taskId = "release1-0000-0000-0000-000000000000";
+  const branchName = "climpire/release1";
+  const worktreePath = path.join(projectPath, ".climpire-worktrees", "release1");
+  fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+  git(projectPath, ["worktree", "add", worktreePath, "-b", branchName, "HEAD"]);
+  const mappedWorktree = { projectPath, worktreePath, branchName };
+
+  return { projectPath, taskId, branchName, worktreePath, mappedWorktree };
+}
+
+function proofFor(
+  input: ReturnType<typeof fixture>,
+  overrides: Partial<WorkspaceReleaseProof> = {},
+): WorkspaceReleaseProof {
+  const worktreeHead = git(input.worktreePath, ["rev-parse", "HEAD"]);
+  const savedHead = git(input.projectPath, ["rev-parse", "refs/heads/main"]);
+  return {
+    executionId: "17d3c7d4-55dd-44b8-82e1-80d88ef2748a",
+    requestFingerprint: "a".repeat(64),
+    mode: "no_local_changes",
+    projectPath: input.projectPath,
+    worktreePath: input.worktreePath,
+    branchName: input.branchName,
+    worktreeHead,
+    savedRef: "refs/heads/main",
+    savedHead,
+    ...overrides,
+  } as WorkspaceReleaseProof;
+}
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("task-scoped safe worktree release", () => {
+  it("accepts only a complete receipt bound to the exact task and proof", () => {
+    const input = fixture();
+    tempDirs.push(input.projectPath);
+    const proof = proofFor(input);
+    const taskWorktrees = new Map([[input.taskId, input.mappedWorktree]]);
+    const receipt = releaseTaskWorktree({
+      taskId: input.taskId,
+      taskProjectPath: input.projectPath,
+      mappedWorktree: input.mappedWorktree,
+      proof,
+      taskWorktrees,
+    });
+
+    expect(workspaceReleaseReceiptMatches(input.taskId, proof, receipt)).toBe(true);
+    expect(workspaceReleaseReceiptMatches(input.taskId, proof, { ...receipt, worktreePath: "/tmp/other" })).toBe(false);
+  });
+
+  it("releases a clean no-change worktree without force and reads back removal", () => {
+    const input = fixture();
+    tempDirs.push(input.projectPath);
+    const taskWorktrees = new Map([[input.taskId, input.mappedWorktree]]);
+
+    const receipt = releaseTaskWorktree({
+      taskId: input.taskId,
+      taskProjectPath: input.projectPath,
+      mappedWorktree: taskWorktrees.get(input.taskId),
+      proof: proofFor(input),
+      taskWorktrees,
+    });
+
+    expect(receipt).toMatchObject({
+      taskId: input.taskId,
+      mode: "no_local_changes",
+      worktreeReleased: true,
+      branchReleased: true,
+    });
+    expect(receipt.proofHash).toMatch(/^[a-f0-9]{64}$/u);
+    expect(fs.existsSync(input.worktreePath)).toBe(false);
+    expect(taskWorktrees.has(input.taskId)).toBe(false);
+    expect(() => git(input.projectPath, ["rev-parse", "--verify", `refs/heads/${input.branchName}`])).toThrow();
+    expect(git(input.projectPath, ["rev-parse", "refs/heads/main"])).toBe(receipt.savedHead);
+  });
+
+  it("releases a clean development worktree only after its commit is reachable from the saved ref", () => {
+    const input = fixture();
+    tempDirs.push(input.projectPath);
+    fs.writeFileSync(path.join(input.worktreePath, "feature.ts"), "export const feature = true;\n");
+    git(input.worktreePath, ["add", "feature.ts"]);
+    git(input.worktreePath, ["commit", "-m", "feat: persist result"]);
+    const worktreeHead = git(input.worktreePath, ["rev-parse", "HEAD"]);
+    git(input.projectPath, ["merge", input.branchName, "--no-ff", "-m", "merge saved result"]);
+    const savedHead = git(input.projectPath, ["rev-parse", "refs/heads/main"]);
+    const taskWorktrees = new Map([[input.taskId, input.mappedWorktree]]);
+
+    const receipt = releaseTaskWorktree({
+      taskId: input.taskId,
+      taskProjectPath: input.projectPath,
+      mappedWorktree: input.mappedWorktree,
+      proof: proofFor(input, {
+        mode: "git_saved",
+        worktreeHead,
+        savedRef: "refs/heads/main",
+        savedHead,
+      }),
+      taskWorktrees,
+    });
+
+    expect(receipt.mode).toBe("git_saved");
+    expect(receipt.worktreeHead).toBe(worktreeHead);
+    expect(receipt.savedHead).toBe(savedHead);
+    expect(git(input.projectPath, ["show", `${savedHead}:feature.ts`])).toBe("export const feature = true;");
+  });
+
+  it("refuses a dirty worktree without deleting its path, branch, or map entry", () => {
+    const input = fixture();
+    tempDirs.push(input.projectPath);
+    fs.writeFileSync(path.join(input.worktreePath, "untracked.txt"), "unsaved\n");
+    const taskWorktrees = new Map([[input.taskId, input.mappedWorktree]]);
+
+    expect(() =>
+      releaseTaskWorktree({
+        taskId: input.taskId,
+        taskProjectPath: input.projectPath,
+        mappedWorktree: input.mappedWorktree,
+        proof: proofFor(input),
+        taskWorktrees,
+      }),
+    ).toThrowError(expect.objectContaining<Partial<WorkspaceReleaseError>>({ code: "workspace_dirty" }));
+
+    expect(fs.existsSync(input.worktreePath)).toBe(true);
+    expect(taskWorktrees.has(input.taskId)).toBe(true);
+    expect(git(input.projectPath, ["rev-parse", `refs/heads/${input.branchName}`])).toMatch(/^[a-f0-9]{40}$/u);
+  });
+
+  it("refuses stale identity and unreachable Git evidence before mutation", () => {
+    for (const mode of ["branch", "head", "saved"] as const) {
+      const input = fixture();
+      tempDirs.push(input.projectPath);
+      const taskWorktrees = new Map([[input.taskId, input.mappedWorktree]]);
+      const proof =
+        mode === "branch"
+          ? proofFor(input, { branchName: "climpire/other" })
+          : mode === "head"
+            ? proofFor(input, { worktreeHead: "0".repeat(40) })
+            : proofFor(input, { mode: "git_saved", savedHead: "f".repeat(40) });
+
+      expect(() =>
+        releaseTaskWorktree({
+          taskId: input.taskId,
+          taskProjectPath: input.projectPath,
+          mappedWorktree: input.mappedWorktree,
+          proof,
+          taskWorktrees,
+        }),
+      ).toThrowError(WorkspaceReleaseError);
+      expect(fs.existsSync(input.worktreePath)).toBe(true);
+      expect(taskWorktrees.has(input.taskId)).toBe(true);
+    }
+  });
+
+  it("refuses a missing saved ref and a real unreachable commit without deleting the worktree", () => {
+    for (const mode of ["missing", "unreachable"] as const) {
+      const input = fixture();
+      tempDirs.push(input.projectPath);
+      fs.writeFileSync(path.join(input.worktreePath, "feature.ts"), "export const feature = true;\n");
+      git(input.worktreePath, ["add", "feature.ts"]);
+      git(input.worktreePath, ["commit", "-m", "feat: not saved"]);
+      const taskWorktrees = new Map([[input.taskId, input.mappedWorktree]]);
+      const proof = proofFor(input, {
+        mode: "git_saved",
+        ...(mode === "missing" ? { savedRef: "refs/heads/missing" } : {}),
+      });
+
+      expect(() =>
+        releaseTaskWorktree({
+          taskId: input.taskId,
+          taskProjectPath: input.projectPath,
+          mappedWorktree: input.mappedWorktree,
+          proof,
+          taskWorktrees,
+        }),
+      ).toThrowError(WorkspaceReleaseError);
+      expect(fs.existsSync(input.worktreePath)).toBe(true);
+      expect(taskWorktrees.has(input.taskId)).toBe(true);
+    }
+  });
+
+  it("refuses to treat the disposable task branch as the persistent saved ref", () => {
+    const input = fixture();
+    tempDirs.push(input.projectPath);
+    fs.writeFileSync(path.join(input.worktreePath, "feature.ts"), "export const feature = true;\n");
+    git(input.worktreePath, ["add", "feature.ts"]);
+    git(input.worktreePath, ["commit", "-m", "feat: only on disposable branch"]);
+    const worktreeHead = git(input.worktreePath, ["rev-parse", "HEAD"]);
+    const taskWorktrees = new Map([[input.taskId, input.mappedWorktree]]);
+
+    expect(() =>
+      releaseTaskWorktree({
+        taskId: input.taskId,
+        taskProjectPath: input.projectPath,
+        mappedWorktree: input.mappedWorktree,
+        proof: proofFor(input, {
+          mode: "git_saved",
+          savedRef: `refs/heads/${input.branchName}`,
+          savedHead: worktreeHead,
+        }),
+        taskWorktrees,
+      }),
+    ).toThrowError(
+      expect.objectContaining<Partial<WorkspaceReleaseError>>({ code: "workspace_release_request_invalid" }),
+    );
+
+    expect(fs.existsSync(input.worktreePath)).toBe(true);
+    expect(git(input.projectPath, ["rev-parse", `refs/heads/${input.branchName}`])).toBe(worktreeHead);
+    expect(() => git(input.projectPath, ["show", "refs/heads/main:feature.ts"])).toThrow();
+  });
+
+  it("revalidates the exact branch HEAD after the durable pre-mutation callback", () => {
+    const input = fixture();
+    tempDirs.push(input.projectPath);
+    const taskWorktrees = new Map([[input.taskId, input.mappedWorktree]]);
+    const proof = proofFor(input);
+
+    expect(() =>
+      releaseTaskWorktree({
+        taskId: input.taskId,
+        taskProjectPath: input.projectPath,
+        mappedWorktree: input.mappedWorktree,
+        proof,
+        taskWorktrees,
+        beforeMutation: () => {
+          fs.writeFileSync(path.join(input.worktreePath, "raced.txt"), "raced\n");
+          git(input.worktreePath, ["add", "raced.txt"]);
+          git(input.worktreePath, ["commit", "-m", "feat: raced after validation"]);
+        },
+      }),
+    ).toThrowError(expect.objectContaining<Partial<WorkspaceReleaseError>>({ code: "workspace_state_changed" }));
+    expect(fs.existsSync(input.worktreePath)).toBe(true);
+    expect(taskWorktrees.has(input.taskId)).toBe(true);
+  });
+});

--- a/server/modules/workflow/core/worktree/release.ts
+++ b/server/modules/workflow/core/worktree/release.ts
@@ -1,0 +1,388 @@
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import type { WorktreeInfo } from "./lifecycle.ts";
+
+export type WorkspaceReleaseMode = "no_local_changes" | "git_saved";
+
+export type WorkspaceReleaseProof = {
+  executionId: string;
+  requestFingerprint: string;
+  mode: WorkspaceReleaseMode;
+  projectPath: string;
+  worktreePath: string;
+  branchName: string;
+  worktreeHead: string;
+  savedRef: string;
+  savedHead: string;
+};
+
+export type WorkspaceReleaseReceipt = WorkspaceReleaseProof & {
+  taskId: string;
+  proofHash: string;
+  worktreeReleased: true;
+  branchReleased: boolean;
+};
+
+export class WorkspaceReleaseError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "WorkspaceReleaseError";
+    this.code = code;
+  }
+}
+
+type ReleaseInput = {
+  taskId: string;
+  taskProjectPath: string;
+  mappedWorktree?: WorktreeInfo;
+  proof: WorkspaceReleaseProof;
+  taskWorktrees: Map<string, WorktreeInfo>;
+  beforeMutation?: () => void;
+};
+
+type GitResult = { ok: boolean; stdout: string };
+
+function runGit(cwd: string, args: string[], input?: string): GitResult {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    input,
+    stdio: [input === undefined ? "ignore" : "pipe", "pipe", "pipe"],
+    timeout: 15_000,
+  });
+  return {
+    ok: !result.error && result.status === 0,
+    stdout: typeof result.stdout === "string" ? result.stdout.trim() : "",
+  };
+}
+
+function requireGit(cwd: string, args: string[], code = "git_inspection_failed"): string {
+  const result = runGit(cwd, args);
+  if (!result.ok) throw new WorkspaceReleaseError(code, "Git state could not be verified");
+  return result.stdout;
+}
+
+function canonicalExisting(value: string): string {
+  try {
+    return fs.realpathSync(value);
+  } catch {
+    throw new WorkspaceReleaseError("workspace_identity_mismatch", "Workspace path does not exist");
+  }
+}
+
+function branchForTask(taskId: string, branchName: string): boolean {
+  const shortId = taskId.slice(0, 8).replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  return new RegExp(`^climpire/${shortId}(?:-[0-9]+)?$`, "u").test(branchName);
+}
+
+function worktreeForTask(taskId: string, projectPath: string, worktreePath: string): boolean {
+  const relative = path.relative(path.join(projectPath, ".climpire-worktrees"), worktreePath);
+  const shortId = taskId.slice(0, 8).replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  return Boolean(relative) && !path.isAbsolute(relative) && new RegExp(`^${shortId}(?:-[0-9]+)?$`, "u").test(relative);
+}
+
+function persistentSavedRef(proof: WorkspaceReleaseProof): boolean {
+  return (
+    /^refs\/heads\/[A-Za-z0-9][A-Za-z0-9._/-]*$/u.test(proof.savedRef) &&
+    !proof.savedRef.includes("..") &&
+    proof.savedRef !== `refs/heads/${proof.branchName}`
+  );
+}
+
+function registeredWorktrees(projectPath: string): Array<{ worktreePath: string; branch?: string }> {
+  return requireGit(projectPath, ["worktree", "list", "--porcelain"])
+    .split(/\n\s*\n/gu)
+    .map((block) => {
+      const values = new Map<string, string>();
+      for (const line of block.split("\n")) {
+        const separator = line.indexOf(" ");
+        if (separator > 0) values.set(line.slice(0, separator), line.slice(separator + 1));
+      }
+      const rawPath = values.get("worktree");
+      if (!rawPath) return undefined;
+      const branchRef = values.get("branch");
+      return {
+        worktreePath: rawPath,
+        ...(branchRef?.startsWith("refs/heads/") ? { branch: branchRef.slice("refs/heads/".length) } : {}),
+      };
+    })
+    .filter((entry): entry is { worktreePath: string; branch?: string } => Boolean(entry));
+}
+
+function meaningfulStatus(worktreePath: string): string[] {
+  const output = requireGit(worktreePath, ["status", "--porcelain"]);
+  if (!output) return [];
+  return output
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .filter((line) => {
+      const candidate = line.slice(3).trim().split(" -> ").pop() ?? "";
+      return candidate !== ".claude/skills" && !candidate.startsWith(".claude/skills/");
+    });
+}
+
+export function workspaceReleaseProofHash(taskId: string, proof: WorkspaceReleaseProof): string {
+  return createHash("sha256")
+    .update(JSON.stringify({ taskId, ...proof }), "utf8")
+    .digest("hex");
+}
+
+export function workspaceReleaseReceiptMatches(
+  taskId: string,
+  proof: WorkspaceReleaseProof,
+  receipt: WorkspaceReleaseReceipt,
+): boolean {
+  return (
+    receipt.taskId === taskId &&
+    receipt.proofHash === workspaceReleaseProofHash(taskId, proof) &&
+    receipt.mode === proof.mode &&
+    receipt.projectPath === proof.projectPath &&
+    receipt.worktreePath === proof.worktreePath &&
+    receipt.branchName === proof.branchName &&
+    receipt.worktreeHead === proof.worktreeHead &&
+    receipt.savedRef === proof.savedRef &&
+    receipt.savedHead === proof.savedHead &&
+    receipt.worktreeReleased === true &&
+    typeof receipt.branchReleased === "boolean"
+  );
+}
+
+export function releaseTaskWorktree(input: ReleaseInput): WorkspaceReleaseReceipt {
+  const { taskId, proof, taskWorktrees } = input;
+  if (
+    !taskId ||
+    !proof.executionId ||
+    !/^[a-f0-9]{64}$/u.test(proof.requestFingerprint) ||
+    !/^[a-f0-9]{40}$/u.test(proof.worktreeHead) ||
+    !/^[a-f0-9]{40}$/u.test(proof.savedHead) ||
+    !persistentSavedRef(proof)
+  ) {
+    throw new WorkspaceReleaseError("workspace_release_request_invalid", "Workspace release proof is invalid");
+  }
+
+  const projectPath = canonicalExisting(proof.projectPath);
+  const worktreePath = canonicalExisting(proof.worktreePath);
+  const taskProjectPath = canonicalExisting(input.taskProjectPath);
+  if (
+    projectPath !== taskProjectPath ||
+    !branchForTask(taskId, proof.branchName) ||
+    !worktreeForTask(taskId, projectPath, worktreePath)
+  ) {
+    throw new WorkspaceReleaseError("workspace_identity_mismatch", "Workspace identity does not match the task");
+  }
+
+  if (input.mappedWorktree) {
+    const mappedProject = canonicalExisting(input.mappedWorktree.projectPath);
+    const mappedWorktree = canonicalExisting(input.mappedWorktree.worktreePath);
+    if (
+      mappedProject !== projectPath ||
+      mappedWorktree !== worktreePath ||
+      input.mappedWorktree.branchName !== proof.branchName
+    ) {
+      throw new WorkspaceReleaseError("workspace_identity_mismatch", "Runtime workspace mapping changed");
+    }
+  }
+
+  if (canonicalExisting(requireGit(projectPath, ["rev-parse", "--show-toplevel"])) !== projectPath) {
+    throw new WorkspaceReleaseError("workspace_identity_mismatch", "Project path is not the Git root");
+  }
+  if (canonicalExisting(requireGit(worktreePath, ["rev-parse", "--show-toplevel"])) !== worktreePath) {
+    throw new WorkspaceReleaseError("workspace_identity_mismatch", "Worktree path is not the Git root");
+  }
+
+  const actualBranch = requireGit(worktreePath, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  const actualHead = requireGit(worktreePath, ["rev-parse", "HEAD"]);
+  const savedHead = requireGit(projectPath, ["rev-parse", "--verify", proof.savedRef], "saved_ref_missing");
+  if (actualBranch !== proof.branchName || actualHead !== proof.worktreeHead) {
+    throw new WorkspaceReleaseError("workspace_state_changed", "Worktree branch or HEAD changed");
+  }
+  if (savedHead !== proof.savedHead) {
+    throw new WorkspaceReleaseError("saved_ref_changed", "Saved Git ref changed");
+  }
+  if (meaningfulStatus(worktreePath).length > 0) {
+    throw new WorkspaceReleaseError("workspace_dirty", "Worktree contains uncommitted or untracked changes");
+  }
+
+  const reachable = runGit(projectPath, ["merge-base", "--is-ancestor", proof.worktreeHead, proof.savedRef]).ok;
+  if (!reachable) {
+    throw new WorkspaceReleaseError("artifact_not_saved", "Worktree commit is not reachable from the saved Git ref");
+  }
+  if (proof.mode === "no_local_changes" && proof.worktreeHead !== proof.savedHead) {
+    throw new WorkspaceReleaseError("artifact_not_saved", "No-change worktree diverged from the saved Git ref");
+  }
+
+  const registered = registeredWorktrees(projectPath);
+  const matches = registered.filter((entry) => {
+    let registeredPath: string;
+    try {
+      registeredPath = fs.realpathSync(entry.worktreePath);
+    } catch {
+      return false;
+    }
+    return registeredPath === worktreePath && entry.branch === proof.branchName;
+  });
+  if (matches.length !== 1) {
+    throw new WorkspaceReleaseError("workspace_identity_mismatch", "Git worktree registration changed");
+  }
+
+  input.beforeMutation?.();
+  const finalBranch = requireGit(worktreePath, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  const finalHead = requireGit(worktreePath, ["rev-parse", "HEAD"]);
+  const finalSavedHead = requireGit(projectPath, ["rev-parse", "--verify", proof.savedRef], "saved_ref_missing");
+  const finalRegistered = registeredWorktrees(projectPath).filter((entry) => {
+    let registeredPath: string;
+    try {
+      registeredPath = fs.realpathSync(entry.worktreePath);
+    } catch {
+      return false;
+    }
+    return registeredPath === worktreePath && entry.branch === proof.branchName;
+  });
+  if (
+    finalBranch !== proof.branchName ||
+    finalHead !== proof.worktreeHead ||
+    finalSavedHead !== proof.savedHead ||
+    meaningfulStatus(worktreePath).length > 0 ||
+    finalRegistered.length !== 1
+  ) {
+    throw new WorkspaceReleaseError("workspace_state_changed", "Workspace state changed before release");
+  }
+
+  const removed = runGit(projectPath, ["worktree", "remove", worktreePath]);
+  if (!removed.ok) {
+    throw new WorkspaceReleaseError("workspace_release_failed", "Git refused the non-force worktree release");
+  }
+
+  const after = registeredWorktrees(projectPath);
+  if (
+    fs.existsSync(worktreePath) ||
+    after.some((entry) => entry.worktreePath === worktreePath || entry.branch === proof.branchName)
+  ) {
+    throw new WorkspaceReleaseError("workspace_release_readback_failed", "Worktree release read-back did not match");
+  }
+
+  const releasedBranchHead = requireGit(projectPath, ["rev-parse", "--verify", `refs/heads/${proof.branchName}`]);
+  if (releasedBranchHead !== proof.worktreeHead) {
+    throw new WorkspaceReleaseError("workspace_state_changed", "Worktree branch changed during release");
+  }
+
+  const branchReleased = runGit(
+    projectPath,
+    ["update-ref", "--stdin"],
+    [
+      "start",
+      `verify ${proof.savedRef} ${proof.savedHead}`,
+      `delete refs/heads/${proof.branchName} ${proof.worktreeHead}`,
+      "prepare",
+      "commit",
+      "",
+    ].join("\n"),
+  ).ok;
+  const branchStillExists = runGit(projectPath, ["rev-parse", "--verify", `refs/heads/${proof.branchName}`]).ok;
+  if (!branchReleased || branchStillExists) {
+    throw new WorkspaceReleaseError("workspace_release_readback_failed", "Branch release read-back did not match");
+  }
+  if (requireGit(projectPath, ["rev-parse", "--verify", proof.savedRef], "saved_ref_missing") !== proof.savedHead) {
+    throw new WorkspaceReleaseError("workspace_release_readback_failed", "Saved Git ref did not survive release");
+  }
+
+  taskWorktrees.delete(taskId);
+  return {
+    taskId,
+    ...proof,
+    proofHash: workspaceReleaseProofHash(taskId, proof),
+    worktreeReleased: true,
+    branchReleased,
+  };
+}
+
+export function reconcileReleasedTaskWorktree(input: ReleaseInput): WorkspaceReleaseReceipt {
+  const { taskId, proof, taskWorktrees } = input;
+  if (
+    !taskId ||
+    !proof.executionId ||
+    !/^[a-f0-9]{64}$/u.test(proof.requestFingerprint) ||
+    !/^[a-f0-9]{40}$/u.test(proof.worktreeHead) ||
+    !/^[a-f0-9]{40}$/u.test(proof.savedHead) ||
+    !persistentSavedRef(proof)
+  ) {
+    throw new WorkspaceReleaseError("workspace_release_request_invalid", "Workspace release proof is invalid");
+  }
+
+  const projectPath = canonicalExisting(proof.projectPath);
+  const taskProjectPath = canonicalExisting(input.taskProjectPath);
+  if (
+    projectPath !== taskProjectPath ||
+    !branchForTask(taskId, proof.branchName) ||
+    !worktreeForTask(taskId, path.resolve(proof.projectPath), path.resolve(proof.worktreePath))
+  ) {
+    throw new WorkspaceReleaseError("workspace_identity_mismatch", "Workspace identity does not match the task");
+  }
+  if (fs.existsSync(proof.worktreePath)) {
+    throw new WorkspaceReleaseError("workspace_reconciliation_incomplete", "Worktree still exists");
+  }
+
+  const savedHead = requireGit(projectPath, ["rev-parse", "--verify", proof.savedRef], "saved_ref_missing");
+  if (savedHead !== proof.savedHead) {
+    throw new WorkspaceReleaseError("saved_ref_changed", "Saved Git ref changed");
+  }
+  if (!runGit(projectPath, ["merge-base", "--is-ancestor", proof.worktreeHead, proof.savedRef]).ok) {
+    throw new WorkspaceReleaseError("artifact_not_saved", "Worktree commit is not reachable from the saved Git ref");
+  }
+  if (proof.mode === "no_local_changes" && proof.worktreeHead !== proof.savedHead) {
+    throw new WorkspaceReleaseError("artifact_not_saved", "No-change worktree diverged from the saved Git ref");
+  }
+
+  const expectedPath = path.resolve(proof.worktreePath);
+  if (
+    registeredWorktrees(projectPath).some(
+      (entry) => path.resolve(entry.worktreePath) === expectedPath || entry.branch === proof.branchName,
+    )
+  ) {
+    throw new WorkspaceReleaseError("workspace_reconciliation_incomplete", "Git still registers the worktree");
+  }
+
+  const branchRef = `refs/heads/${proof.branchName}`;
+  const branch = runGit(projectPath, ["rev-parse", "--verify", branchRef]);
+  if (branch.ok && branch.stdout !== proof.worktreeHead) {
+    throw new WorkspaceReleaseError(
+      "workspace_state_changed",
+      "Retained branch no longer matches the released worktree",
+    );
+  }
+  const branchReleased = branch.ok
+    ? runGit(
+        projectPath,
+        ["update-ref", "--stdin"],
+        [
+          "start",
+          `verify ${proof.savedRef} ${proof.savedHead}`,
+          `delete ${branchRef} ${proof.worktreeHead}`,
+          "prepare",
+          "commit",
+          "",
+        ].join("\n"),
+      ).ok
+    : true;
+  const branchStillExists = runGit(projectPath, ["rev-parse", "--verify", branchRef]).ok;
+  if (!branchReleased || branchStillExists) {
+    throw new WorkspaceReleaseError("workspace_release_readback_failed", "Branch release read-back did not match");
+  }
+  if (requireGit(projectPath, ["rev-parse", "--verify", proof.savedRef], "saved_ref_missing") !== proof.savedHead) {
+    throw new WorkspaceReleaseError("workspace_release_readback_failed", "Saved Git ref did not survive release");
+  }
+
+  taskWorktrees.delete(taskId);
+  return {
+    taskId,
+    ...proof,
+    proofHash: workspaceReleaseProofHash(taskId, proof),
+    worktreeReleased: true,
+    branchReleased,
+  };
+}

--- a/server/modules/workflow/orchestration/review-finalize-tools.ts
+++ b/server/modules/workflow/orchestration/review-finalize-tools.ts
@@ -11,6 +11,19 @@ import { reconcileVideoRenderDelegationState } from "./video-render-delegation-s
 
 type CreateReviewFinalizeToolsDeps = Record<string, any>;
 
+function requiresHermesWorkspaceRelease(workflowMetaJson: unknown): boolean {
+  if (typeof workflowMetaJson !== "string" || !workflowMetaJson.trim()) return false;
+  try {
+    const root = JSON.parse(workflowMetaJson) as { hermes_execution?: { contract?: unknown } };
+    return (
+      root.hermes_execution?.contract === "hermes-claw-execution/v1" ||
+      root.hermes_execution?.contract === "hermes-claw-execution/v2"
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function createReviewFinalizeTools(deps: CreateReviewFinalizeToolsDeps) {
   const {
     db,
@@ -131,11 +144,7 @@ export function createReviewFinalizeTools(deps: CreateReviewFinalizeToolsDeps) {
     options?: { bypassProjectDecisionGate?: boolean; trigger?: string },
   ): void {
     const lang = resolveLang(taskTitle);
-    const currentTask = db
-      .prepare(
-        "SELECT status, department_id, source_task_id, project_id, workflow_pack_key, project_path FROM tasks WHERE id = ?",
-      )
-      .get(taskId) as
+    const currentTask = db.prepare("SELECT * FROM tasks WHERE id = ?").get(taskId) as
       | {
           status: string;
           department_id: string | null;
@@ -143,9 +152,15 @@ export function createReviewFinalizeTools(deps: CreateReviewFinalizeToolsDeps) {
           project_id: string | null;
           workflow_pack_key: string | null;
           project_path: string | null;
+          workflow_meta_json?: string | null;
         }
       | undefined;
     if (!currentTask || currentTask.status !== "review") return; // Already moved or cancelled
+
+    if (requiresHermesWorkspaceRelease(currentTask.workflow_meta_json)) {
+      appendTaskLog(taskId, "system", "Review hold: waiting for Hermes result storage and workspace release receipt");
+      return;
+    }
 
     if (!options?.bypassProjectDecisionGate && !currentTask.source_task_id && currentTask.project_id) {
       const gateSnapshot = getProjectReviewGateSnapshot(currentTask.project_id);

--- a/server/modules/workflow/orchestration/review-finalize-tools.video-gate.test.ts
+++ b/server/modules/workflow/orchestration/review-finalize-tools.video-gate.test.ts
@@ -17,6 +17,7 @@ function createDb(): DatabaseSync {
       project_id TEXT,
       workflow_pack_key TEXT,
       project_path TEXT,
+      workflow_meta_json TEXT,
       created_at INTEGER DEFAULT 0,
       updated_at INTEGER DEFAULT 0
     );
@@ -35,6 +36,44 @@ function createDb(): DatabaseSync {
 }
 
 describe("review finalize video gate", () => {
+  it("Hermes task waits for a persisted workspace release receipt", () => {
+    const db = createDb();
+    try {
+      const taskId = "task-hermes-release";
+      db.prepare(
+        `
+          INSERT INTO tasks (
+            id, title, status, department_id, source_task_id, project_id,
+            workflow_pack_key, project_path, workflow_meta_json, created_at, updated_at
+          ) VALUES (?, ?, 'review', 'development', NULL, NULL, 'development', ?, ?, 1, 1)
+        `,
+      ).run(
+        taskId,
+        "Hermes unattended development",
+        "/tmp/hermes-ticket-worktree",
+        JSON.stringify({ hermes_execution: { contract: "hermes-claw-execution/v2" } }),
+      );
+      const appendTaskLog = vi.fn();
+      const tools = createReviewFinalizeTools({
+        db,
+        resolveLang: () => "en",
+        appendTaskLog,
+      } as any);
+
+      tools.finishReview(taskId, "Hermes unattended development");
+
+      const updated = db.prepare("SELECT status FROM tasks WHERE id = ?").get(taskId) as { status: string };
+      expect(updated.status).toBe("review");
+      expect(appendTaskLog).toHaveBeenCalledWith(
+        taskId,
+        "system",
+        "Review hold: waiting for Hermes result storage and workspace release receipt",
+      );
+    } finally {
+      db.close();
+    }
+  });
+
   it("video_preprod task는 final.mp4 확인 전 승인/머지를 진행하지 않는다", () => {
     const db = createDb();
     try {

--- a/server/modules/workflow/packs/notion-managed-development.test.ts
+++ b/server/modules/workflow/packs/notion-managed-development.test.ts
@@ -20,7 +20,7 @@ function setupDb(): DatabaseSync {
 }
 
 describe("Notion managed development scope", () => {
-  it("returns only departments referenced by development-pack Hermes members", () => {
+  it("returns the complete Notion department catalog when development-pack Hermes members exist", () => {
     const db = setupDb();
     try {
       const marker = (hex: string) => `hermes-member:${hex.repeat(64)}\n\nprofile`;
@@ -31,9 +31,25 @@ describe("Notion managed development scope", () => {
 
       expect(readNotionManagedDevelopmentScope(db as any)).toEqual({
         agentIds: ["athena", "hermes"],
-        departmentIds: ["dev", "secretariat"],
+        departmentIds: [
+          "representative",
+          "secretariat",
+          "marketing",
+          "social",
+          "sales",
+          "dev",
+          "backoffice",
+        ],
       });
-      expect(readNotionManagedDevelopmentDepartmentIds(db as any)).toEqual(["dev", "secretariat"]);
+      expect(readNotionManagedDevelopmentDepartmentIds(db as any)).toEqual([
+        "representative",
+        "secretariat",
+        "marketing",
+        "social",
+        "sales",
+        "dev",
+        "backoffice",
+      ]);
     } finally {
       db.close();
     }

--- a/server/modules/workflow/packs/notion-managed-development.test.ts
+++ b/server/modules/workflow/packs/notion-managed-development.test.ts
@@ -1,0 +1,52 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+
+import {
+  readNotionManagedDevelopmentDepartmentIds,
+  readNotionManagedDevelopmentScope,
+} from "./notion-managed-development.ts";
+
+function setupDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec(`
+    CREATE TABLE agents (
+      id TEXT PRIMARY KEY,
+      department_id TEXT,
+      workflow_pack_key TEXT,
+      personality TEXT
+    );
+  `);
+  return db;
+}
+
+describe("Notion managed development scope", () => {
+  it("returns only departments referenced by development-pack Hermes members", () => {
+    const db = setupDb();
+    try {
+      const marker = (hex: string) => `hermes-member:${hex.repeat(64)}\n\nprofile`;
+      db.prepare("INSERT INTO agents VALUES (?, ?, ?, ?)").run("athena", "dev", "development", marker("a"));
+      db.prepare("INSERT INTO agents VALUES (?, ?, ?, ?)").run("hermes", "secretariat", null, marker("b"));
+      db.prepare("INSERT INTO agents VALUES (?, ?, ?, ?)").run("foreign", "qa", "report", marker("c"));
+      db.prepare("INSERT INTO agents VALUES (?, ?, ?, ?)").run("default", "planning", "development", "default agent");
+
+      expect(readNotionManagedDevelopmentScope(db as any)).toEqual({
+        agentIds: ["athena", "hermes"],
+        departmentIds: ["dev", "secretariat"],
+      });
+      expect(readNotionManagedDevelopmentDepartmentIds(db as any)).toEqual(["dev", "secretariat"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("returns null to preserve vanilla development behavior when no valid marker exists", () => {
+    const db = setupDb();
+    try {
+      db.prepare("INSERT INTO agents VALUES (?, ?, ?, ?)").run("default", "planning", "development", "default agent");
+      db.prepare("INSERT INTO agents VALUES (?, ?, ?, ?)").run("invalid", "dev", "development", `hermes-member:${"z".repeat(64)}`);
+      expect(readNotionManagedDevelopmentDepartmentIds(db as any)).toBeNull();
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/server/modules/workflow/packs/notion-managed-development.ts
+++ b/server/modules/workflow/packs/notion-managed-development.ts
@@ -16,6 +16,16 @@ export type NotionManagedDevelopmentScope = {
   departmentIds: string[];
 };
 
+export const NOTION_MANAGED_DEVELOPMENT_DEPARTMENT_IDS = [
+  "representative",
+  "secretariat",
+  "marketing",
+  "social",
+  "sales",
+  "dev",
+  "backoffice",
+] as const;
+
 export function readNotionManagedDevelopmentScope(db: ReadDatabase): NotionManagedDevelopmentScope | null {
   let hasWorkflowPackColumn = false;
   try {
@@ -40,10 +50,9 @@ export function readNotionManagedDevelopmentScope(db: ReadDatabase): NotionManag
     const agentIds = rows
       .map(({ id }) => String(id ?? "").trim())
       .filter(Boolean);
-    const departmentIds = [...new Set(rows
-      .map(({ department_id }) => String(department_id ?? "").trim())
-      .filter(Boolean))].sort();
-    return agentIds.length > 0 && departmentIds.length > 0 ? { agentIds, departmentIds } : null;
+    return agentIds.length > 0
+      ? { agentIds, departmentIds: [...NOTION_MANAGED_DEVELOPMENT_DEPARTMENT_IDS] }
+      : null;
   } catch {
     return null;
   }

--- a/server/modules/workflow/packs/notion-managed-development.ts
+++ b/server/modules/workflow/packs/notion-managed-development.ts
@@ -1,0 +1,54 @@
+type QueryRows = { all(...params: unknown[]): unknown[] };
+
+type ReadDatabase = {
+  prepare(sql: string): QueryRows;
+};
+
+const MARKER_PREDICATE = `
+  substr(personality, 1, 14) = 'hermes-member:'
+  AND length(substr(personality, 15, 64)) = 64
+  AND substr(personality, 15, 64) NOT GLOB '*[^0-9a-f]*'
+  AND substr(personality, 79, 1) IN ('', char(10))
+`;
+
+export type NotionManagedDevelopmentScope = {
+  agentIds: string[];
+  departmentIds: string[];
+};
+
+export function readNotionManagedDevelopmentScope(db: ReadDatabase): NotionManagedDevelopmentScope | null {
+  let hasWorkflowPackColumn = false;
+  try {
+    const columns = db.prepare("PRAGMA table_info(agents)").all() as Array<{ name?: unknown }>;
+    hasWorkflowPackColumn = columns.some(({ name }) => String(name ?? "").trim() === "workflow_pack_key");
+  } catch {
+    return null;
+  }
+  const workflowPackPredicate = hasWorkflowPackColumn
+    ? "COALESCE(workflow_pack_key, 'development') = 'development'"
+    : "1 = 1";
+  try {
+    const rows = db.prepare(`
+      SELECT id, department_id
+      FROM agents
+      WHERE ${workflowPackPredicate}
+        AND department_id IS NOT NULL
+        AND trim(department_id) <> ''
+        AND ${MARKER_PREDICATE}
+      ORDER BY id ASC
+    `).all() as Array<{ id?: unknown; department_id?: unknown }>;
+    const agentIds = rows
+      .map(({ id }) => String(id ?? "").trim())
+      .filter(Boolean);
+    const departmentIds = [...new Set(rows
+      .map(({ department_id }) => String(department_id ?? "").trim())
+      .filter(Boolean))].sort();
+    return agentIds.length > 0 && departmentIds.length > 0 ? { agentIds, departmentIds } : null;
+  } catch {
+    return null;
+  }
+}
+
+export function readNotionManagedDevelopmentDepartmentIds(db: ReadDatabase): string[] | null {
+  return readNotionManagedDevelopmentScope(db)?.departmentIds ?? null;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -370,8 +370,9 @@ export default function App() {
         packKey: activePackKey,
         globalDepartments: departments,
         packDepartments: activePackProfile?.departments ?? null,
+        visibleAgents: agents,
       }),
-    [activePackKey, activePackProfile?.departments, departments],
+    [activePackKey, activePackProfile?.departments, agents, departments],
   );
   const { mergedAgents: overlayAgents } = useMemo(
     () =>

--- a/src/app/AppMainLayout.tsx
+++ b/src/app/AppMainLayout.tsx
@@ -500,8 +500,8 @@ export default function AppMainLayout({
             {view === "dashboard" && (
               <Dashboard
                 stats={stats}
-                agents={agents}
-                tasks={tasks}
+                agents={officeScopedAgents}
+                tasks={tasksForActivePack}
                 companyName={settings.companyName}
                 onPrimaryCtaClick={() => setView("tasks")}
               />

--- a/src/app/AppMainLayout.tsx
+++ b/src/app/AppMainLayout.tsx
@@ -285,8 +285,9 @@ export default function AppMainLayout({
         globalDepartments: departments,
         packDepartments: packProfileDepartments,
         preferPackProfile: !isHydratedOfficePack,
+        visibleAgents: agents,
       }),
-    [departments, isHydratedOfficePack, officePackKey, packProfileDepartments],
+    [agents, departments, isHydratedOfficePack, officePackKey, packProfileDepartments],
   );
 
   const { scopedAgents: officeScopedAgents, mergedAgents: displayAgents } = useMemo(
@@ -301,20 +302,26 @@ export default function AppMainLayout({
 
   const managerDepartments =
     officePackKey === "development"
-      ? departments
+      ? displayDepartments
       : isHydratedOfficePack
         ? displayDepartments
         : (activePackProfile?.departments ?? generatedOfficePresentation.departments);
 
   const managerAgents =
     officePackKey === "development"
-      ? agents
+      ? displayAgents
       : isHydratedOfficePack
         ? officeScopedAgents
         : (activePackProfile?.agents ?? seededPackAgents);
 
   const officePresentation = useMemo(() => {
-    if (officePackKey === "development") return generatedOfficePresentation;
+    if (officePackKey === "development") {
+      return {
+        departments: displayDepartments,
+        agents: officeScopedAgents,
+        roomThemes: generatedOfficePresentation.roomThemes,
+      };
+    }
     return {
       departments: displayDepartments,
       agents: officeScopedAgents,

--- a/src/app/office-pack-display.test.ts
+++ b/src/app/office-pack-display.test.ts
@@ -208,8 +208,13 @@ describe("office pack display helpers", () => {
     });
     const departments = [
       makeDepartment({ id: "planning", name: "Planning", name_ko: "Planning", name_ja: "企画チーム" }),
-      makeDepartment({ id: "dev", name: "Development", name_ko: "Development", name_ja: "🎨 開発部門" }),
-      makeDepartment({ id: "secretariat", name: "Secretariat", name_ko: "Secretariat", name_ja: "🧑‍💼 秘書室" }),
+      makeDepartment({ id: "representative", name: "代表", name_ko: "代表", name_ja: "代表", icon: "👤" }),
+      makeDepartment({ id: "secretariat", name: "秘書室", name_ko: "秘書室", name_ja: "秘書室", icon: "🧑‍💼" }),
+      makeDepartment({ id: "marketing", name: "マーケティング部門", name_ko: "マーケティング部門", name_ja: "マーケティング部門", icon: "📊" }),
+      makeDepartment({ id: "social", name: "SNS運用部門", name_ko: "SNS運用部門", name_ja: "SNS運用部門", icon: "🌏" }),
+      makeDepartment({ id: "sales", name: "営業部門", name_ko: "営業部門", name_ja: "営業部門", icon: "💸" }),
+      makeDepartment({ id: "dev", name: "開発部門", name_ko: "開発部門", name_ja: "開発部門", icon: "🎨" }),
+      makeDepartment({ id: "backoffice", name: "バックオフィス部門", name_ko: "バックオフィス部門", name_ja: "バックオフィス部門", icon: "⚙️" }),
       makeDepartment({ id: "qa", name: "QA", name_ko: "QA", name_ja: "品質管理チーム" }),
     ];
 
@@ -225,9 +230,24 @@ describe("office pack display helpers", () => {
 
     expect(scopedAgents.map((agent) => agent.id)).toEqual(["athena", "iris", "hermes"]);
     expect(mergedAgents.map((agent) => agent.id)).toEqual(["athena", "iris", "hermes"]);
-    expect(visibleDepartments.map((department) => department.id)).toEqual(["dev", "secretariat"]);
-    expect(visibleDepartments[0]?.name_ja).toBe("🎨 開発部門");
-    expect(visibleDepartments[1]?.name_ja).toBe("🧑‍💼 秘書室");
+    expect(visibleDepartments.map((department) => department.id)).toEqual([
+      "representative",
+      "secretariat",
+      "marketing",
+      "social",
+      "sales",
+      "dev",
+      "backoffice",
+    ]);
+    expect(visibleDepartments.map(({ name_ja, icon }) => [name_ja, icon])).toEqual([
+      ["代表", "👤"],
+      ["秘書室", "🧑‍💼"],
+      ["マーケティング部門", "📊"],
+      ["SNS運用部門", "🌏"],
+      ["営業部門", "💸"],
+      ["開発部門", "🎨"],
+      ["バックオフィス部門", "⚙️"],
+    ]);
   });
 
   it("keeps the normal development roster when no Notion-linked agent exists", () => {

--- a/src/app/office-pack-display.test.ts
+++ b/src/app/office-pack-display.test.ts
@@ -15,6 +15,7 @@ function makeAgent(input: Partial<Agent> & { id: string; name: string; name_ko: 
     avatar_emoji: input.avatar_emoji ?? "A",
     sprite_number: input.sprite_number ?? null,
     personality: input.personality ?? null,
+    workflow_pack_key: input.workflow_pack_key,
     status: input.status ?? "idle",
     current_task_id: input.current_task_id ?? null,
     stats_tasks_done: input.stats_tasks_done ?? 0,
@@ -163,5 +164,88 @@ describe("office pack display helpers", () => {
     expect(mergedAgents.some((agent) => agent.id === "novel-seed-1")).toBe(true);
     expect(mergedAgents.some((agent) => agent.id === "report-seed-1")).toBe(false);
     expect(mergedAgents.some((agent) => agent.id === "dev-leader")).toBe(true);
+  });
+
+  it("shows only Notion-linked agents and their department in the development pack", () => {
+    const linkedAthena = makeAgent({
+      id: "athena",
+      name: "Athena",
+      name_ko: "Athena",
+      name_ja: "アテナ",
+      department_id: "dev",
+      personality: `hermes-member:${"a".repeat(64)}\n\n正式所属: 🎨 開発部門`,
+    });
+    const linkedIris = makeAgent({
+      id: "iris",
+      name: "Iris",
+      name_ko: "Iris",
+      name_ja: "アイリス",
+      department_id: "dev",
+      personality: `hermes-member:${"b".repeat(64)}\n\n正式所属: 🎨 開発部門`,
+    });
+    const defaultAgent = makeAgent({
+      id: "default-sage",
+      name: "Sage",
+      name_ko: "Sage",
+      department_id: "planning",
+      personality: "Default planning agent",
+    });
+    const foreignPackLinkedAgent = makeAgent({
+      id: "foreign-linked",
+      name: "Foreign Linked",
+      name_ko: "Foreign Linked",
+      department_id: "qa",
+      workflow_pack_key: "report",
+      personality: `hermes-member:${"c".repeat(64)}\n\n正式所属: 別部門`,
+    });
+    const departments = [
+      makeDepartment({ id: "planning", name: "Planning", name_ko: "Planning", name_ja: "企画チーム" }),
+      makeDepartment({ id: "dev", name: "Development", name_ko: "Development", name_ja: "🎨 開発部門" }),
+      makeDepartment({ id: "qa", name: "QA", name_ko: "QA", name_ja: "品質管理チーム" }),
+    ];
+
+    const { scopedAgents, mergedAgents } = resolvePackAgentViews({
+      packKey: "development",
+      globalAgents: [defaultAgent, linkedAthena, linkedIris, foreignPackLinkedAgent],
+    });
+    const visibleDepartments = resolvePackDepartmentsForDisplay({
+      packKey: "development",
+      globalDepartments: departments,
+      visibleAgents: mergedAgents,
+    });
+
+    expect(scopedAgents.map((agent) => agent.id)).toEqual(["athena", "iris"]);
+    expect(mergedAgents.map((agent) => agent.id)).toEqual(["athena", "iris"]);
+    expect(visibleDepartments.map((department) => department.id)).toEqual(["dev"]);
+    expect(visibleDepartments[0]?.name_ja).toBe("🎨 開発部門");
+  });
+
+  it("keeps the normal development roster when no Notion-linked agent exists", () => {
+    const agent = makeAgent({ id: "default", name: "Default", name_ko: "Default", department_id: "planning" });
+    const foreignPackLinkedAgent = makeAgent({
+      id: "foreign-linked",
+      name: "Foreign Linked",
+      name_ko: "Foreign Linked",
+      department_id: "dev",
+      workflow_pack_key: "report",
+      personality: `hermes-member:${"d".repeat(64)}\n\n正式所属: 別部門`,
+    });
+    const departments = [
+      makeDepartment({ id: "planning", name: "Planning", name_ko: "Planning" }),
+      makeDepartment({ id: "dev", name: "Development", name_ko: "Development" }),
+    ];
+
+    const { mergedAgents } = resolvePackAgentViews({
+      packKey: "development",
+      globalAgents: [agent, foreignPackLinkedAgent],
+    });
+    const visibleDepartments = resolvePackDepartmentsForDisplay({
+      packKey: "development",
+      globalDepartments: departments,
+      visibleAgents: mergedAgents,
+    });
+
+    expect(mergedAgents).toEqual([agent]);
+    expect(visibleDepartments).toEqual(departments);
   });
 });

--- a/src/app/office-pack-display.test.ts
+++ b/src/app/office-pack-display.test.ts
@@ -183,6 +183,14 @@ describe("office pack display helpers", () => {
       department_id: "dev",
       personality: `hermes-member:${"b".repeat(64)}\n\n正式所属: 🎨 開発部門`,
     });
+    const linkedHermes = makeAgent({
+      id: "hermes",
+      name: "Hermes",
+      name_ko: "Hermes",
+      name_ja: "エルメス",
+      department_id: "secretariat",
+      personality: `hermes-member:${"e".repeat(64)}\n\n正式所属: 🧑‍💼 秘書室`,
+    });
     const defaultAgent = makeAgent({
       id: "default-sage",
       name: "Sage",
@@ -201,12 +209,13 @@ describe("office pack display helpers", () => {
     const departments = [
       makeDepartment({ id: "planning", name: "Planning", name_ko: "Planning", name_ja: "企画チーム" }),
       makeDepartment({ id: "dev", name: "Development", name_ko: "Development", name_ja: "🎨 開発部門" }),
+      makeDepartment({ id: "secretariat", name: "Secretariat", name_ko: "Secretariat", name_ja: "🧑‍💼 秘書室" }),
       makeDepartment({ id: "qa", name: "QA", name_ko: "QA", name_ja: "品質管理チーム" }),
     ];
 
     const { scopedAgents, mergedAgents } = resolvePackAgentViews({
       packKey: "development",
-      globalAgents: [defaultAgent, linkedAthena, linkedIris, foreignPackLinkedAgent],
+      globalAgents: [defaultAgent, linkedAthena, linkedIris, linkedHermes, foreignPackLinkedAgent],
     });
     const visibleDepartments = resolvePackDepartmentsForDisplay({
       packKey: "development",
@@ -214,10 +223,11 @@ describe("office pack display helpers", () => {
       visibleAgents: mergedAgents,
     });
 
-    expect(scopedAgents.map((agent) => agent.id)).toEqual(["athena", "iris"]);
-    expect(mergedAgents.map((agent) => agent.id)).toEqual(["athena", "iris"]);
-    expect(visibleDepartments.map((department) => department.id)).toEqual(["dev"]);
+    expect(scopedAgents.map((agent) => agent.id)).toEqual(["athena", "iris", "hermes"]);
+    expect(mergedAgents.map((agent) => agent.id)).toEqual(["athena", "iris", "hermes"]);
+    expect(visibleDepartments.map((department) => department.id)).toEqual(["dev", "secretariat"]);
     expect(visibleDepartments[0]?.name_ja).toBe("🎨 開発部門");
+    expect(visibleDepartments[1]?.name_ja).toBe("🧑‍💼 秘書室");
   });
 
   it("keeps the normal development roster when no Notion-linked agent exists", () => {

--- a/src/app/office-pack-display.ts
+++ b/src/app/office-pack-display.ts
@@ -9,6 +9,16 @@ function parseSeedPackKey(agentId: string): string | null {
 
 const HERMES_MEMBER_MARKER = /^hermes-member:[a-f0-9]{64}(?:\n|$)/u;
 
+const NOTION_MANAGED_DEVELOPMENT_DEPARTMENT_IDS = [
+  "representative",
+  "secretariat",
+  "marketing",
+  "social",
+  "sales",
+  "dev",
+  "backoffice",
+] as const;
+
 function isDevelopmentPackAgent(agent: Agent): boolean {
   return (agent.workflow_pack_key ?? "development") === "development";
 }
@@ -49,8 +59,10 @@ export function resolvePackDepartmentsForDisplay(params: {
   if (packKey === "development") {
     const notionManagedAgents = (visibleAgents ?? []).filter(isNotionManagedDevelopmentAgent);
     if (notionManagedAgents.length > 0) {
-      const visibleDepartmentIds = new Set(notionManagedAgents.map((agent) => agent.department_id));
-      return globalDepartments.filter((department) => visibleDepartmentIds.has(department.id));
+      const departmentsById = new Map(globalDepartments.map((department) => [department.id, department]));
+      return NOTION_MANAGED_DEVELOPMENT_DEPARTMENT_IDS
+        .map((departmentId) => departmentsById.get(departmentId))
+        .filter((department): department is Department => Boolean(department));
     }
     return globalDepartments;
   }

--- a/src/app/office-pack-display.ts
+++ b/src/app/office-pack-display.ts
@@ -7,6 +7,18 @@ function parseSeedPackKey(agentId: string): string | null {
   return matched?.[1] ? matched[1] : null;
 }
 
+const HERMES_MEMBER_MARKER = /^hermes-member:[a-f0-9]{64}(?:\n|$)/u;
+
+function isDevelopmentPackAgent(agent: Agent): boolean {
+  return (agent.workflow_pack_key ?? "development") === "development";
+}
+
+function isNotionManagedDevelopmentAgent(agent: Agent): boolean {
+  return isDevelopmentPackAgent(agent)
+    && typeof agent.personality === "string"
+    && HERMES_MEMBER_MARKER.test(agent.personality);
+}
+
 function mergePackAgent(globalAgent: Agent | undefined, packAgent: Agent): Agent {
   // DB row is the source of truth after hydration.
   if (globalAgent) return globalAgent;
@@ -31,11 +43,18 @@ export function resolvePackDepartmentsForDisplay(params: {
   globalDepartments: Department[];
   packDepartments?: Department[] | null;
   preferPackProfile?: boolean;
+  visibleAgents?: Agent[] | null;
 }): Department[] {
-  const { packKey, globalDepartments, packDepartments, preferPackProfile = true } = params;
-  if (packKey === "development" || !packDepartments || packDepartments.length === 0) {
+  const { packKey, globalDepartments, packDepartments, preferPackProfile = true, visibleAgents } = params;
+  if (packKey === "development") {
+    const notionManagedAgents = (visibleAgents ?? []).filter(isNotionManagedDevelopmentAgent);
+    if (notionManagedAgents.length > 0) {
+      const visibleDepartmentIds = new Set(notionManagedAgents.map((agent) => agent.department_id));
+      return globalDepartments.filter((department) => visibleDepartmentIds.has(department.id));
+    }
     return globalDepartments;
   }
+  if (!packDepartments || packDepartments.length === 0) return globalDepartments;
 
   const globalById = new Map<string, Department>();
   for (const department of globalDepartments) {
@@ -55,7 +74,13 @@ export function resolvePackAgentViews(params: {
   packAgents?: Agent[] | null;
 }): { scopedAgents: Agent[]; mergedAgents: Agent[] } {
   const { packKey, globalAgents, packAgents } = params;
-  if (packKey === "development" || !packAgents || packAgents.length === 0) {
+  if (packKey === "development") {
+    const developmentAgents = globalAgents.filter(isDevelopmentPackAgent);
+    const notionManagedAgents = developmentAgents.filter(isNotionManagedDevelopmentAgent);
+    const visibleDevelopmentAgents = notionManagedAgents.length > 0 ? notionManagedAgents : developmentAgents;
+    return { scopedAgents: visibleDevelopmentAgents, mergedAgents: visibleDevelopmentAgents };
+  }
+  if (!packAgents || packAgents.length === 0) {
     return { scopedAgents: globalAgents, mergedAgents: globalAgents };
   }
 


### PR DESCRIPTION
## Summary\n- add a task-scoped, non-force worktree release endpoint for Hermes-managed review tasks\n- require exact execution identity, clean Git state, persistent saved-ref reachability, CSRF/auth, and durable task-log receipts\n- atomically verify the saved ref and delete only the disposable task branch\n- keep native review auto-finalization on hold until Hermes completes the release/read-back contract\n\n## Safety\n- validation failures delete nothing\n- retries converge through prepared/receipt logs\n- prior execution receipts cannot finalize a new execution\n- explicit discard cannot be reconciled into a false receipt\n\n## Verification\n- API: 217 tests passed\n- Web: 76 tests passed\n- TypeScript/build passed\n- OpenAPI check passed\n- ESLint passed with pre-existing warnings only\n- independent review: no Critical/Important findings